### PR TITLE
feat: opt-in RESTART_POLICY for boot persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ PORT=8888
 # on every request, and start.sh's own readiness/status/smoke checks send it
 # automatically. Leave empty for an open (LAN-trusted) server.
 API_KEY=
+# Docker restart policy for both serving containers. "no" (default) = current
+# behavior; "unless-stopped" = containers come back after a host reboot and
+# the 2-node rendezvous re-forms (both hosts must reboot cleanly; after a
+# single-side crash, prefer rerunning ./start.sh).
+RESTART_POLICY=
 HOST_BIND=0.0.0.0
 DIST_PORT=26400
 

--- a/start.sh
+++ b/start.sh
@@ -110,6 +110,8 @@
 #    HF_HOME=~/.cache/huggingface        head-side HF cache
 #    WORKER_HF_HOME=<auto>      worker-side HF cache (default $HOME/.cache/…)
 #    DIST_PORT=26400            2-node rendezvous port on the head
+#    RESTART_POLICY=no          docker restart policy for both containers;
+#                               "unless-stopped" = survive host reboots
 #    DOWNLOAD_MODE=rsync        rsync (head→worker) | direct (worker pulls too)
 #    MEM_FRACTION_STATIC=0.70   GB10 math: 0.70×122 GB GPU + 26 GB pinned PLE
 #                               + OS ≈ 119 of 122 GB — do not raise past ~0.75
@@ -240,6 +242,14 @@ API_KEY="${API_KEY:-}"
 # treats as failure -- without this, wait_ready times out on a healthy server.
 AUTH_CURL=()
 [[ -n "${API_KEY}" ]] && AUTH_CURL=(-H "Authorization: Bearer ${API_KEY}")
+# Docker restart policy for the two serving containers. Default "no" keeps
+# current behavior (a host reboot needs a manual ./start.sh). Set
+# RESTART_POLICY=unless-stopped for boot persistence: after a clean reboot of
+# BOTH hosts the containers relaunch and the TP rendezvous re-forms on its
+# own. Note: on a single-container crash the restarted rank re-enters
+# rendezvous against a peer that never died -- if the pair does not recover,
+# run ./start.sh (idempotent) to relaunch both sides coherently.
+RESTART_POLICY="${RESTART_POLICY:-no}"
 
 # ---- Paths / logs -----------------------------------------------------------
 HF_HOME="${HF_HOME:-${HOME}/.cache/huggingface}"
@@ -994,6 +1004,7 @@ launch() {
   info "starting worker (node-rank 1) on ${WORKER_SSH} …"
   worker_docker run -d \
     --name "${WORKER_CONTAINER}" \
+    --restart "${RESTART_POLICY}" \
     --network host --ipc host --gpus all \
     --shm-size 32g \
     --device /dev/infiniband --cap-add IPC_LOCK \
@@ -1021,6 +1032,7 @@ launch() {
   info "starting head (node-rank 0, API on ${HOST_BIND}:${PORT}) …"
   docker run -d \
     --name "${HEAD_CONTAINER}" \
+    --restart "${RESTART_POLICY}" \
     --network host --ipc host --gpus all \
     --shm-size 32g \
     --device /dev/infiniband --cap-add IPC_LOCK \


### PR DESCRIPTION
Companion QoL to the API_KEY PR, from the same production deploy:

The serving containers run with docker's default restart policy, so **a host reboot silently takes the deployment down** until someone reruns `./start.sh`. For a recipe that positions itself as production ("a single-file, production recipe"), surviving reboots seems worth offering.

- `RESTART_POLICY=` env (default `no` = exact current behavior)
- `unless-stopped` brings both containers back after a clean reboot of the pair, and the TP rendezvous re-forms
- docs are explicit about the single-side-crash caveat: a restarted rank re-enters rendezvous against a peer that never died, which may not recover — `./start.sh` (idempotent) remains the coherent-relaunch path for that case, which is also why this stays opt-in rather than default

Happy to fold both PRs into one if you prefer fewer merges.