### PR TITLE
fix: pin SGLang's cross-node MessageQueue to the ConnectX link

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1004,6 +1004,7 @@ launch() {
     -v "${worker_cache_root}/flashinfer-qwen38-flash-next:/root/.cache/flashinfer" \
     "${worker_preload[@]}" \
     $(common_docker_env) \
+    -e SGLANG_HOST_IP="${WORKER_CX7_IP}" \
     -e NCCL_SOCKET_IFNAME="${WORKER_CX7_IF}" \
     -e GLOO_SOCKET_IFNAME="${WORKER_CX7_IF}" \
     -e TP_SOCKET_IFNAME="${WORKER_CX7_IF}" \
@@ -1031,6 +1032,7 @@ launch() {
     -v "${FLASHINFER_CACHE_DIR}:/root/.cache/flashinfer" \
     "${head_preload[@]}" \
     $(common_docker_env) \
+    -e SGLANG_HOST_IP="${HEAD_CX7_IP}" \
     -e NCCL_SOCKET_IFNAME="${HEAD_CX7_IF}" \
     -e GLOO_SOCKET_IFNAME="${HEAD_CX7_IF}" \
     -e TP_SOCKET_IFNAME="${HEAD_CX7_IF}" \


### PR DESCRIPTION
Fixes the two-node startup freeze reported in #3, on a third pair of DGX Sparks.

## What was happening

SGLang opens a cross-node ZeroMQ `MessageQueue` **in addition to** NCCL/Gloo, and auto-detects the address it advertises:

```python
# shm_broadcast.py
connect_ip = get_local_ip_auto("0.0.0.0") if n_remote_reader > 0 else "127.0.0.1"
```

On a multi-NIC Spark that returned the **Wi-Fi address**, not the ConnectX-7 address this recipe already pins `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME` / `TP_SOCKET_IFNAME` to. The head binds there, the worker cannot reach it, and both ranks park in `shm_broadcast.wait_until_ready()` — **after** NCCL has succeeded. That is why the last line is always `CustomAllreduce is disabled …` and `Init torch distributed ends` never prints.

Auto-detection only runs when `n_remote_reader > 0`, so single node (`127.0.0.1`) is unaffected — which matches "single-node works, TP=2 hangs".

## The change

Two `docker run` env entries, placed with the existing socket-interface pins:

- worker: `-e SGLANG_HOST_IP="${WORKER_CX7_IP}"`
- head: `-e SGLANG_HOST_IP="${HEAD_CX7_IP}"`

No new knobs, no `.env` changes, no behaviour change to NCCL, PLE, memory fractions or the SM121 kernel patch. It just hands the addresses the recipe already has to the one subsystem that was guessing.

There is currently no way for a user to do this themselves: `common_docker_env()` is a hard-coded array, `.env.example` has no such key, and `EXTRA_ARGS` appends sglang CLI args rather than container env.

## Verification

A/B positive control on 2× GB10, ConnectX-7 direct link:

| `SGLANG_HOST_IP` | Result |
| --- | --- |
| Wi-Fi (`192.168.0.213` / `192.168.0.46`) | hang reproduced — both ranks in `wait_until_ready`, worker socket `SYN-SENT`, no `Load weight begin` |
| RoCE (`192.168.200.1` / `192.168.200.2`) | `Init torch distributed ends. elapsed=1.57 s` → weights → API ready → `start.sh smoke` returns real text |

With the fix: weight load 425 s, target 72.86 GB + NEXTN draft 0.99 GB, 32.12 GB free after CUDA graphs, API ready at 508 s, ~53 tok/s single-stream end-to-end. NCCL stayed on the bundled 2.29.7 — no host NCCL needed. `MEM_FRACTION_STATIC=0.70`, `CHUNKED_PREFILL_SIZE=4096` and PLE auto-offload were left untouched.

On our hosts the LAN address was unreachable because UFW is default-deny (`[UFW BLOCK] … DPT=38611 SYN` in dmesg while SSH to the same address worked). The fix is right independently of that, though: otherwise SGLang's inter-node metadata rides Wi-Fi instead of the 200 Gb link.

Details, including what could not be inspected without root, are in the issue comment on #3.

## Not covered

This does not touch HCA/GID/RoCE routing, so the separately reported bare-NCCL `proxy.cc … Connect res=3` failure is unaffected. Reporters on #3 can confirm this is their failure mode with `get_local_ip_auto()`, a `py-spy dump`, and `ss -tanp | grep SYN-SENT`.
