### PR TITLE
fix: two keyed-server blind spots — kv-eval 401s, and the issue #8 pool guard silently skips

### DIFF
--- a/evals/nvfp4_kv_eval.py
+++ b/evals/nvfp4_kv_eval.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import random
 import re
 import sys
@@ -96,6 +97,11 @@ def _color(enabled: bool, code: str, text: str) -> str:
     return f"\033[{code}m{text}\033[0m"
 
 
+# Populated from --api-key / $API_KEY before the first request. A keyed server
+# 401s every probe otherwise, which surfaces as "API not reachable".
+_AUTH_HEADER: dict[str, str] = {}
+
+
 def _http_json(
     url: str,
     *,
@@ -106,7 +112,8 @@ def _http_json(
     req = urllib.request.Request(
         url,
         data=data,
-        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        headers={"Content-Type": "application/json", "Accept": "application/json",
+                 **_AUTH_HEADER},
         method="GET" if payload is None else "POST",
     )
     return urllib.request.urlopen(req, timeout=timeout)
@@ -843,6 +850,8 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         description="Needle-in-haystack reliability eval for NVFP4 KV cache"
     )
     p.add_argument("--base-url", default="http://127.0.0.1:8888")
+    p.add_argument("--api-key", default=os.environ.get("API_KEY", ""),
+                   help="bearer token for a keyed server (default: $API_KEY)")
     p.add_argument("--model", default="Qwen3.8-Flash-Next-NVFP4")
     p.add_argument("--suite", choices=sorted(SUITES), default="quick")
     p.add_argument("--depths", help="comma-separated token depths, overrides --suite")
@@ -862,7 +871,10 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 
 
 def main() -> int:
-    return run(parse_args())
+    args = parse_args()
+    if args.api_key:
+        _AUTH_HEADER["Authorization"] = "Bearer " + args.api_key
+    return run(args)
 
 
 if __name__ == "__main__":

--- a/start.sh
+++ b/start.sh
@@ -403,7 +403,7 @@ text = sys.stdin.read()
 m = re.search(r"^sglang:max_total_num_tokens\{[^}]*\}\s+(\S+)", text, re.M)
 print(int(float(m.group(1))) if m else 0)
 ' || true)"
-  ctx="$(curl -fsS --max-time 10 "http://127.0.0.1:${PORT}/get_server_info" 2>/dev/null | python3 -c '
+  ctx="$(curl -fsS "${AUTH_CURL[@]}" --max-time 10 "http://127.0.0.1:${PORT}/get_server_info" 2>/dev/null | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 print(int(d.get("context_length") or 0))
@@ -2004,6 +2004,6 @@ case "${ACTION}" in
   status)   cmd_status ;;
   logs)     cmd_logs "${2:-head}" ;;
   smoke)    cmd_smoke ;;
-  kv-eval)  shift; exec python3 "${SCRIPT_DIR}/evals/nvfp4_kv_eval.py" --base-url "http://127.0.0.1:${PORT}" --model "${SERVED_MODEL_NAME}" "$@" ;;
+  kv-eval)  shift; exec python3 "${SCRIPT_DIR}/evals/nvfp4_kv_eval.py" --base-url "http://127.0.0.1:${PORT}" --model "${SERVED_MODEL_NAME}" --api-key "${EFFECTIVE_API_KEY}" "$@" ;;
   doctor)   cmd_doctor ;;
 esac


### PR DESCRIPTION
Two keyed-server blind spots, both the same class as #7 and both in code added after it. Found while upgrading a 2× DGX Spark pair from `dccb035` to current `main`.

## 1. `kv-eval` cannot authenticate at all

`evals/nvfp4_kv_eval.py` has no `--api-key` and never sets an `Authorization` header, so on a keyed server every probe 401s and the run aborts immediately:

```
NVFP4 KV eval  2026-08-27T09:55:19Z
  endpoint  http://127.0.0.1:8888
API not reachable at http://127.0.0.1:8888: HTTP Error 401: Unauthorized
```

Fix: `--api-key` defaulting to `$API_KEY`, injected into `_http_json` — the single request path, so one hook covers every probe. `start.sh kv-eval` forwards `EFFECTIVE_API_KEY` (already derived at startup, so it also picks up a key that only exists in `EXTRA_ARGS`).

## 2. The issue #8 pool guard silently skips on keyed servers

`boot_health_check()` reads `/get_server_info` without `AUTH_CURL`. That endpoint requires auth; `/metrics` does not. So `pool` reads fine, `ctx` comes back `0`, the `(( pool > 0 && ctx > 0 ))` test fails, and the guard degrades to:

```
━━━ KV pool vs advertised context ━━━
[WARN]  could not read pool/context from the live API — skip size check
```

Measured on the same pair:

```
/get_server_info unauth -> 401
/get_server_info authed -> 200
/metrics         unauth -> 200
```

So the fail-closed check added for #8 never fires on a keyed deployment — and a keyed deployment is exactly what we were running when we hit #8 (a 137,408-token pool advertising 262,144, silently truncating a real client's 137.5K conversation). It fails *open* precisely where it matters.

Fix: pass `"${AUTH_CURL[@]}"`, matching how `wait_ready` and `cmd_status` already do it.

## Verification

On 2× DGX Spark (GB10 / SM121) TP2, 1M YaRN, `NVFP4_KV_CACHE=1`, five-key server:

- `./start.sh kv-eval` now runs: pool **1,826,752 tokens / 7.19 GB**, `nvfp4=True`, cases **11/11**, niah **7/7**, verdict **RELIABLE** — independently reproducing the 11/11 in your CHANGELOG.
- The pool guard now reports **1.74× one context-length request** instead of skipping.
- `bash -n start.sh` clean; `nvfp4_kv_eval.py --help` renders the new flag, and argparse shows the literal `$API_KEY` rather than a resolved secret.

`--api-key` on the eval takes the key on the command line, which is visible in `ps` for the duration of the run. `$API_KEY` from the environment is the quieter path and is the default; happy to make the flag env-only if you'd rather not offer the argument at all.

Unrelated but while I'm here: thanks for landing the #8 fix and #7 so fast — the 0.80 default took our pair from a 5-request admission cap to 28, and NVFP4 KV took the pool from 624K bf16 tokens to 1.83M for less memory.
