### PR TITLE
fix: create .sglang*.log owner-only — they capture the API key verbatim

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1842,6 +1842,10 @@ launch() {
   trap cleanup_followers EXIT
 
   : >"${LOG_FILE}"; : >"${WORKER_LOG_FILE}"
+  # The sglang startup banner captured here contains server_args, which embeds
+  # the configured --api-key verbatim. Create the logs owner-only so the key
+  # set is not left world-readable between runs.
+  chmod 600 "${LOG_FILE}" "${WORKER_LOG_FILE}"
   echo "[$(date -Is)] launching ${MODEL_ID} TP=${TP_SIZE} nnodes=${NNODES} image=${IMAGE}" >>"${LOG_FILE}"
 
   # Stale containers from a previous run


### PR DESCRIPTION
## Motivation

`start.sh` captures the sglang startup banner into `.sglang.log` /
`.sglang-worker.log`. That banner is `server_args=ServerArgs(…)`, which includes
`api_key='…'` verbatim — sglang does not redact it
([sgl-project/sglang#18518](https://github.com/sgl-project/sglang/pull/18518) is
the open, already-approved fix for that, unmerged since March).

Both logs are created at the ambient umask — 0664 on a stock Ubuntu account — so
on a keyed deployment every boot writes the configured API key to a
world-readable file, and it stays there across restarts. Anyone who can read the
directory can read the key.

This is worse with `API_KEY` set to more than one key: sglang's `--api-key` is a
single string, so a comma-separated set lands in the log as one line containing
every key at once.

## Reproduction

```bash
API_KEY=sk-test-123 ./start.sh
stat -c '%a' .sglang.log          # 664
grep -c 'sk-test-123' .sglang.log # 1
```

## Modifications

`chmod 600` on both log files immediately after they are created, next to the
existing `: >` truncation. Four lines, no behaviour change otherwise.

The keys are still in the log *contents* — that needs the upstream sglang fix.
This just stops the file being world-readable in the meantime. Keys also remain
visible in `/proc/<pid>/cmdline` because `--api-key` is argv; no change here can
address that.

Follow-on to #1, which added `API_KEY` support in the first place.

## Checklist

- [x] Shell syntax checked (`bash -n start.sh`)
- [x] Verified on two live TP=2 clusters (2× DGX Spark GB10 each)
- [x] No change to model/inference behaviour
