### PR TITLE
fix: wrun() must pass ssh -n, and harden the fabric preflight (MTU 9000, ibv_devices, fail-fast on unreachable peer)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -330,7 +330,12 @@ derive_effective_api_key() {
 
 # ---- Remote helpers (worker = spark2 via ssh alias) -------------------------
 wrun() { # remote shell snippet
-  ssh "${SSH_OPTS[@]}" "${WORKER_SSH}" "$1"
+  # -n (stdin from /dev/null) belongs HERE and not in SSH_OPTS: scp and rsync -e
+  # share SSH_OPTS, and -n breaks rsync's transport. Without it, ssh inherits the
+  # caller's stdin and silently consumes it -- running any script that calls wrun
+  # from inside `ssh host bash -s <<EOF` swallows the rest of the heredoc, so the
+  # worker step succeeds and every later line vanishes with no error.
+  ssh -n "${SSH_OPTS[@]}" "${WORKER_SSH}" "$1"
 }
 worker_docker() { # docker <argv…> on the worker, each arg shell-quoted
   local q=() a
@@ -471,7 +476,39 @@ preflight() { # $1 = action; port checks only matter when serving
   if ping -c 1 -W 2 "${WORKER_CX7_IP}" >/dev/null 2>&1; then
     ok "CX7 link head ${HEAD_CX7_IP} ↔ worker ${WORKER_CX7_IP} reachable"
   else
-    warn "cannot ping ${WORKER_CX7_IP} — 2-node rendezvous may fail"
+    error "cannot reach ${WORKER_CX7_IP} over the CX7 fabric — TP rendezvous will hang, not fail fast"
+    exit 1
+  fi
+
+  # MTU 9000, asserted end-to-end rather than read from one side. RoCE derives its
+  # IB MTU from the netdev MTU, so a single end left at 1500 silently caps the whole
+  # TP group -- and a default-size ping cannot see it.
+  if ping -c 1 -W 2 -M do -s 8972 "${WORKER_CX7_IP}" >/dev/null 2>&1; then
+    ok "fabric MTU 9000 verified end-to-end (8972B unfragmented)"
+  else
+    error "MTU 9000 not usable head→${WORKER_CX7_IP}: an 8972-byte unfragmented ping failed."
+    error "  check both ends: ip link show ${HEAD_CX7_IF} / ${WORKER_CX7_IF} (expect mtu 9000)"
+    exit 1
+  fi
+  local hmtu; hmtu="$(cat "/sys/class/net/${HEAD_CX7_IF}/mtu" 2>/dev/null || echo 0)"
+  (( hmtu >= 9000 )) || { error "head ${HEAD_CX7_IF} MTU is ${hmtu}, expected 9000"; exit 1; }
+  local wmtu; wmtu="$(wrun "cat /sys/class/net/${WORKER_CX7_IF}/mtu 2>/dev/null || echo 0")"
+  (( wmtu >= 9000 )) || { error "worker ${WORKER_CX7_IF} MTU is ${wmtu}, expected 9000"; exit 1; }
+  ok "netdev MTU head ${hmtu} / worker ${wmtu}"
+
+  # The configured RoCE device must actually exist on each node: NCCL_IB_HCA naming
+  # a device that is not present degrades silently instead of erroring.
+  if ibv_devices 2>/dev/null | grep -qw "${HEAD_CX7_IB}"; then
+    ok "head RoCE device ${HEAD_CX7_IB} present"
+  else
+    error "head RoCE device '${HEAD_CX7_IB}' not in ibv_devices — fix HEAD_CX7_IB"
+    exit 1
+  fi
+  if wrun "ibv_devices 2>/dev/null | grep -qw '${WORKER_CX7_IB}'"; then
+    ok "worker RoCE device ${WORKER_CX7_IB} present"
+  else
+    error "worker RoCE device '${WORKER_CX7_IB}' not in ibv_devices — fix WORKER_CX7_IB"
+    exit 1
   fi
 
   # Disk: needs depend on what is already cached (weights are ~135 GB)


### PR DESCRIPTION
Two silent-failure classes found while bringing up a second 2× GB10 pair from this recipe.

## 1. `wrun()` needs `ssh -n`

`wrun()` inherits the caller's stdin, so `ssh` consumes it. Any script that calls it from inside a heredoc-fed `bash -s` has the **remainder of the script silently eaten**: the worker step succeeds, every later line vanishes, exit status is 0, and nothing is logged.

`./stop.sh` is the everyday case. Driving it remotely, the worker stops and then every command after it is silently discarded. That cost us a genuinely confusing debugging session — the pair was down and our follow-up steps had simply never run.

The fix is one flag, but **placement matters**: `-n` goes at the `wrun()` call site, *not* in `SSH_OPTS`, because `scp` and `rsync -e` share `SSH_OPTS` and `-n` would break rsync's transport.

## 2. The fabric preflight warns where it should assert

`preflight` pinged the worker's CX7 IP at default size and only `warn`ed on failure. Three gaps:

- **MTU is never verified.** RoCE derives its IB MTU from the netdev MTU, so a single end left at 1500 caps the entire TP group — and a 56-byte ping cannot see it. Worth catching here specifically because the README already tells operators MTU 9000 is required; the check just wasn't there.
- **An unreachable fabric peer only warned**, so the run continued into a rendezvous hang rather than failing fast with a clear cause.
- **`*_CX7_IB` was never checked against `ibv_devices`.** A wrong device name doesn't error; NCCL degrades quietly.

This adds an `-M do -s 8972` ping end-to-end so 9000 is proven in the path rather than read off one side, the netdev MTU read on **both** nodes, the configured RoCE device asserted present in `ibv_devices` on **both** nodes, and `error`/`exit 1` instead of `warn` when the fabric peer is unreachable.

## Validation

On a correctly configured 2× GB10 pair (200 Gb/s DAC, MTU 9000 both ends, `rocep1s0f0`):

```
PASS: 8972B unfragmented ping ok
  head mtu(enp1s0f0np0)=9000
  worker mtu(enp1s0f0np0)=9000
PASS: head sees rocep1s0f0
PASS: worker sees rocep1s0f0
PASS: 20000B correctly rejected (assert has teeth)
```

The last line is the negative control — the MTU assert fails when it should, rather than passing vacuously. No false positive on healthy hardware. `bash -n start.sh` clean.
