### PR TITLE
fix: verify worker weights by bytes, not just file count (a truncated shard passes today)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1548,9 +1548,9 @@ resolve_snapshot() { # → absolute host path of the snapshot (or fail)
   return 1
 }
 
-verify_snapshot() { # <snapshot_dir> <label> — byte-size check against the HF API
-  local dir="$1" label="$2"
-  python3 - "${MODEL_ID}" "${dir}" "${label}" <<'PY' || return 1
+# The per-file byte check, kept as a program string so it can run on either
+# node: python3 on the head, and shipped to the worker by verify_snapshot_worker.
+VERIFY_SNAPSHOT_PY="$(cat <<'PY'
 import json, os, sys, urllib.request
 model, snap, label = sys.argv[1], sys.argv[2], sys.argv[3]
 url = f"https://huggingface.co/api/models/{model}?blobs=true"
@@ -1584,6 +1584,67 @@ if missing or bad:
 total = sum(s for _, s in files)
 print(f"[OK]    {label}: all {len(files)} files verified ({total/1e9:.2f} GB)")
 PY
+)"
+
+verify_snapshot() { # <snapshot_dir> <label> — byte-size check against the HF API
+  local dir="$1" label="$2"
+  python3 - "${MODEL_ID}" "${dir}" "${label}" <<<"${VERIFY_SNAPSHOT_PY}" || return 1
+}
+
+verify_snapshot_worker() { # <worker snapshot_dir> <label> — the same check, on the worker
+  local dir="$1" label="$2" b64
+  if ! wrun "command -v python3 >/dev/null 2>&1"; then
+    warn "${label}: no python3 on the worker — skipping the per-file check (the byte total is still compared)"
+    return 0
+  fi
+  # Ship the program as part of the command, never on stdin: wrun's ssh has to
+  # leave stdin alone or it eats a caller's heredoc.
+  b64="$(printf '%s' "${VERIFY_SNAPSHOT_PY}" | base64 | tr -d '\n')"
+  wrun "printf %s '${b64}' | base64 -d | python3 - '${MODEL_ID}' '${dir}' '${label}'" || return 1
+}
+
+# Total logical bytes under a snapshots/ tree. -L dereferences, because a
+# snapshot is a directory of symlinks into ../../blobs/ and the link's own size
+# is meaningless. %.0f not %d: mawk overflows a 135 GB total with %d.
+snapshot_bytes() { # <dir> → bytes
+  find -L "$1" -type f -printf '%s\n' 2>/dev/null \
+    | awk '{t+=$1} END{printf "%.0f\n", t+0}'
+}
+
+worker_snapshot_bytes() { # <worker dir> → bytes
+  wrun "find -L '$1' -type f -printf '%s\n' 2>/dev/null | awk '{t+=\$1} END{printf \"%.0f\n\", t+0}'" \
+    || echo 0
+}
+
+worker_snapshot_dir() { # <worker repo dir> → the snapshot holding config.json (or fail)
+  local wrepo="$1" d=""
+  if [[ -n "${HF_REVISION}" ]] \
+     && wrun "test -f '${wrepo}/snapshots/${HF_REVISION}/config.json'" 2>/dev/null; then
+    echo "${wrepo}/snapshots/${HF_REVISION}"; return 0
+  fi
+  d="$(wrun "find '${wrepo}/snapshots' -maxdepth 2 -name config.json -printf '%h\n' 2>/dev/null | head -1" || true)"
+  [[ -n "${d}" ]] || return 1
+  echo "${d}"
+}
+
+# Byte-level acceptance for the worker copy. A truncated shard keeps the file
+# count intact, so the count check alone accepts it and you find out at weight
+# load — or as garbage output.
+verify_worker_weights() { # <worker repo dir> [head_bytes]
+  local wrepo="$1" head_bytes="${2:-}" wsnap wbytes
+  wsnap="$(worker_snapshot_dir "${wrepo}")" \
+    || { error "worker snapshot has no config.json under ${wrepo}/snapshots"; return 1; }
+  wbytes="$(worker_snapshot_bytes "${wrepo}/snapshots")"
+  if [[ -n "${head_bytes}" ]]; then
+    if [[ "${wbytes}" != "${head_bytes}" ]]; then
+      error "worker bytes ${wbytes} != head ${head_bytes} — truncated or partial shard; rerun to resume"
+      return 1
+    fi
+    ok "worker byte total matches head (${wbytes} bytes)"
+  else
+    info "worker byte total ${wbytes}"
+  fi
+  verify_snapshot_worker "${wsnap}" "worker cache" || return 1
 }
 
 download_on_head() {
@@ -1643,6 +1704,10 @@ sync_weights_to_worker() {
 import glob, sys
 sys.exit(0 if glob.glob('/root/.cache/huggingface/hub/${REPO_CACHE_DIRNAME}/snapshots/*/model.safetensors.index.json') else 1)
 " >/dev/null 2>&1; then
+      verify_worker_weights "${wrepo}" || {
+        error "worker weights failed verification — delete ${wrepo} on the worker and rerun"
+        exit 1
+      }
       ok "weights already on worker"
       return 0
     fi
@@ -1654,6 +1719,10 @@ sys.exit(0 if glob.glob('/root/.cache/huggingface/hub/${REPO_CACHE_DIRNAME}/snap
 from huggingface_hub import snapshot_download
 snapshot_download('${MODEL_ID}', token=None, revision='${HF_REVISION}' or None)
 " || { error "worker download failed — try DOWNLOAD_MODE=rsync"; exit 1; }
+    verify_worker_weights "${wrepo}" || {
+      error "worker download incomplete — rerun (snapshot_download resumes)"
+      exit 1
+    }
     ok "weights downloaded on worker"
     return 0
   fi
@@ -1661,12 +1730,25 @@ snapshot_download('${MODEL_ID}', token=None, revision='${HF_REVISION}' or None)
   # rsync head → worker over the CX7 link (single internet download; resumable)
   # Count under snapshots/ only — .locks lives in the repo dir on the head but
   # is excluded from the rsync, so counting the whole repo would never match.
-  local hcount wcount
+  local hcount wcount hbytes wbytes
   hcount="$(find "$(snapshot_root)/snapshots" \( -type f -o -type l \) 2>/dev/null | wc -l)"
   wcount="$(wrun "find '${wrepo}/snapshots' \( -type f -o -type l \) 2>/dev/null | wc -l" || echo 0)"
-  if [[ "${hcount}" == "${wcount}" ]] && wrun "test -f '${wrepo}/snapshots'/*/config.json" 2>/dev/null; then
-    ok "weights already synced to worker (${wcount} files)"
+  hbytes="$(snapshot_bytes "$(snapshot_root)/snapshots")"
+  wbytes="$(worker_snapshot_bytes "${wrepo}/snapshots")"
+  info "head ${hcount} files / ${hbytes} bytes · worker ${wcount} files / ${wbytes} bytes"
+  if [[ "${hcount}" == "${wcount}" && "${hbytes}" == "${wbytes}" ]] \
+     && wrun "test -f '${wrepo}/snapshots'/*/config.json" 2>/dev/null; then
+    verify_worker_weights "${wrepo}" "${hbytes}" || {
+      error "worker weights failed verification — delete ${wrepo} on the worker and rerun"
+      exit 1
+    }
+    ok "weights already synced to worker (${wcount} files / ${wbytes} bytes)"
     return 0
+  fi
+  # A count match with a byte mismatch is the truncated-shard case: fall through
+  # and let rsync repair it rather than failing here (it resumes).
+  if [[ "${hcount}" == "${wcount}" && "${hbytes}" != "${wbytes}" ]]; then
+    warn "worker file count matches but bytes differ (${wbytes} != ${hbytes}) — re-syncing"
   fi
   info "rsyncing weights head → worker (~135 GB over the CX7 link, resumable) …"
   rsync -a --partial --info=progress2,stats1 --exclude '.locks' \
@@ -1679,7 +1761,11 @@ snapshot_download('${MODEL_ID}', token=None, revision='${HF_REVISION}' or None)
     exit 1
   fi
   wrun "test -f '${wrepo}/snapshots'/*/config.json" 2>/dev/null || { error "worker snapshot incomplete"; exit 1; }
-  ok "weights synced to worker (${wcount} files)"
+  verify_worker_weights "${wrepo}" "${hbytes}" || {
+    error "worker weights failed verification — rerun to resume"
+    exit 1
+  }
+  ok "weights synced to worker (${wcount} files / ${hbytes} bytes)"
 }
 
 # =============================================================================


### PR DESCRIPTION
## The defect

`sync_weights_to_worker()` accepts the worker's copy on a **file+symlink count**
match under `snapshots/`, plus `config.json` existing. That is the whole
acceptance test, on both the "already synced" early return and after the rsync:

```bash
hcount="$(find "$(snapshot_root)/snapshots" \( -type f -o -type l \) … | wc -l)"
wcount="$(wrun "find '${wrepo}/snapshots' \( -type f -o -type l \) … | wc -l")"
if [[ "${hcount}" == "${wcount}" ]] && wrun "test -f '${wrepo}/snapshots'/*/config.json"; then
  ok "weights already synced to worker (${wcount} files)"
```

Meanwhile `verify_snapshot()` — which does a real per-file byte check against
the HF manifest — is called **only from `download_on_head()`**. The worker never
runs it, in either `DOWNLOAD_MODE`.

## The concrete failure mode

A **truncated shard keeps the file count intact**. A killed rsync, a full disk
on the worker, an interrupted `snapshot_download` — the file exists, the name is
right, the count matches, the check passes. You find out at weight load, or you
don't find out at all and serve garbage.

The early return makes it durable: once a bad copy is in place, every subsequent
`./start.sh` re-accepts it without ever looking at the bytes.

Note this is only about the *worker*. The head is already covered.

## Why bytes are not redundant with the count

On the pair I develop against, the same pinned revision materialises as
**419 files / 135,253,622,894 bytes** in one cache and 421 files with a
different byte total in another (extra local files that are not in the HF
manifest). So the count is not even a stable identity for a revision — which is
exactly why I compare byte totals only where they are supposed to be
byte-identical (`rsync` mode, where the worker is a mirror of the head's repo
dir) and lean on `verify_snapshot`'s per-file manifest check everywhere else.

## The change

- **Byte total as well as count**, `find -L … -printf '%s\n'` so symlinks are
  dereferenced (a snapshot is a directory of links into `../../blobs/`; the
  link's own size is meaningless). `awk … printf "%.0f"`, not `%d` — mawk, which
  is `/usr/bin/awk` on Ubuntu, overflows a 135 GB total with `%d`.
- **`verify_snapshot` now runs on the worker too.** The python program moved
  into a `VERIFY_SNAPSHOT_PY` string so either node can run it; the head path is
  unchanged. It is shipped to the worker base64-encoded **as part of the
  command, never on stdin** — `wrun`'s ssh has to leave stdin alone or it eats a
  caller's heredoc (same hazard as #13). If the worker has no `python3` it warns
  and the byte-total compare still stands; if the HF API is unreachable the
  program's existing heuristic fallback applies, unchanged.
- Wired into **both** `DOWNLOAD_MODE`s and into the early returns.
- A count match with a **byte** mismatch `warn`s and falls through to the rsync
  (it resumes) instead of failing; anything still wrong after the sync fails
  closed, matching the surrounding style.

Not included: a `refs/main` byte-comparison. `resolve_snapshot()` already reads
it with `tr -d ' \n'`, which is more tolerant than the hub's own `f.read()`, so
there is nothing to fix there.

## Validation

`bash -n start.sh` clean. Then, on a live 2× GB10 pair (head + CX7-linked
worker, 419-file / 135.25 GB NVFP4 checkpoint, `HF_REVISION` sha-pinned), the
new helpers driven directly:

**Positive — the real trees:**

```
== head files/bytes ==
files: 419
bytes: 135253622894
== worker files/bytes ==
files: 419
bytes: 135253622894
== worker snapshot dir ==
/home/…/hub/models--RadixArk--Qwen3.8-Flash-Next-NVFP4/snapshots/7b71922524…
== verify_worker_weights ==
[OK]    worker byte total matches head (135253622894 bytes)
[OK]    worker cache: all 419 files verified (135.25 GB)
RESULT: PASS
```

That second `[OK]` is `verify_snapshot`'s own program, executed **on the
worker**, against the HF manifest.

**Negative — one shard truncated to 1 MiB** (a symlink mirror of the real
snapshot with a single `layer-00000-experts-0000-0127.safetensors` replaced by
its first 1 MiB, so the file count is untouched):

```
GOOD  files=419  bytes=135253622894
TRUNC files=419  bytes=134900573262      <-- count identical, 353 MB missing
```

The count check cannot see that. Both new checks can, independently:

```
== A. byte-total compare vs the real head total ==
[ERROR] worker bytes 134900571627 != head 135253622894 — truncated or partial shard; rerun to resume
RESULT: rejected (correct)

== B. same fixture, byte compare skipped — worker-side per-file check only ==
[ERROR] worker cache: size mismatch layer-00000-experts-0000-0127.safetensors (1048576 != 354098208)
RESULT: rejected (correct)
```

and on the head path, unchanged code, same fixture:

```
[ERROR] truncated fixture: size mismatch layer-00000-experts-0000-0127.safetensors (1048576 != 354098208)
RESULT: rejected, rc=1
```

Fixtures were symlink mirrors sharing the real blobs (~1 MiB of actual disk) and
were removed from both nodes afterwards. No serving process was restarted or
reconfigured for this.

I left `CHANGELOG.md` alone deliberately — I have two other small PRs open
against this file's neighbours and did not want three branches all editing the
same changelog block.
