### PR TITLE
perf: make the CHUNKED_PREFILL_SIZE=1024 default conditional on context > native (+15…23% prefill at 262144)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ DIST_PORT=26400
 # default; this cluster's 1M YaRN recipe uses 0.82 + CHUNKED_PREFILL_SIZE=1024.
 MEM_FRACTION_STATIC=0.80
 CONTEXT_LENGTH=1048576
+# Unset = 4096 at native 262144 context, 1024 above it (a 4096 chunk at 300k
+# history froze GB10). Set it only to override that; >1024 above native is
+# clamped back to 1024 with a warning.
 CHUNKED_PREFILL_SIZE=1024
 MAX_RUNNING_REQUESTS=28
 # 0 = over-length prompts 400; 1 = --allow-auto-truncate (silent trim).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ All notable changes to this serving recipe.
 - `MAX_RUNNING_REQUESTS` default **28**. `CUDA_GRAPH_BS` is extended to match
   so decode steps above 16 stay graphed. (This cluster's YaRN `.env` at
   `MAMBA_FULL_MEMORY_RATIO=0.3` still caps at **14** mamba slots.)
-- `CHUNKED_PREFILL_SIZE` default **1024**; clamped to 1024 when context > 262144
-  (chunk 4096 at 300k history froze GB10).
+- `CHUNKED_PREFILL_SIZE` default is now **per context**: **4096** at or below
+  native 262144, **1024** above it. Still clamped to 1024 when
+  context > 262144 (chunk 4096 at 300k history froze GB10). The unconditional
+  1024 cost 15–23% of prefill at native context on 2× GB10 TP2.
 - `--allow-auto-truncate` is **opt-in** (`ALLOW_AUTO_TRUNCATE=1`). Over-length
   prompts return 400 instead of silent trim.
 - After boot, `start.sh` **refuses** if the KV pool cannot hold one advertised

--- a/start.sh
+++ b/start.sh
@@ -126,7 +126,9 @@
 #                               1M YaRN recipe uses 0.82 + chunk 1024 in .env.
 #    CONTEXT_LENGTH=1048576     YaRN 1M default (factor 4.0 × native 262144).
 #                               Set 262144 for native (no YaRN). Hard-capped at 1M.
-#    CHUNKED_PREFILL_SIZE=1024  Keep ≤1024 when context > 262144 (indexer workspace).
+#    CHUNKED_PREFILL_SIZE=      empty = 4096 at native context, 1024 above it.
+#                               Keep ≤1024 when context > 262144 (indexer
+#                               workspace); >1024 there is clamped with a warn.
 #    MAX_PREFILL_TOKENS=        empty = 2048 under YaRN, else unset
 #    MAX_RUNNING_REQUESTS=28    mamba ceiling at 0.80 + default mamba ratio
 #                               (~141 slots / 5). 16 silently queues past c=16.
@@ -230,10 +232,20 @@ SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-Qwen3.8-Flash-Next-NVFP4}"
 
 MEM_FRACTION_STATIC="${MEM_FRACTION_STATIC:-0.80}"   # GB10: PLE is inside this budget (issue #8)
 CONTEXT_LENGTH="${CONTEXT_LENGTH:-1048576}"   # YaRN 1M; 262144 = native, no YaRN
-CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-1024}"
 MAX_PREFILL_TOKENS="${MAX_PREFILL_TOKENS:-}"  # empty = 2048 when YaRN, else unset
 YARN_NATIVE_CTX=262144
 YARN_MAX_CTX=1048576
+# Chunk size is only cheap above native context, where a 4096 chunk at 300k
+# history froze GB10. At or below native it costs real prefill throughput
+# (measured +15…23% for 4096 over 1024 on 2× GB10 TP2), and the model card
+# recipe this script follows uses 4096 at --context-length 262144. So default
+# per context; an explicit CHUNKED_PREFILL_SIZE always wins, and the >native
+# clamp below still applies to it.
+if (( CONTEXT_LENGTH > YARN_NATIVE_CTX )); then
+  CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-1024}"
+else
+  CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-4096}"
+fi
 YARN_OVERRIDE_ARGS='{"text_config":{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144},"max_position_embeddings":1048576}}'
 MAX_RUNNING_REQUESTS="${MAX_RUNNING_REQUESTS:-28}"
 ALLOW_AUTO_TRUNCATE="${ALLOW_AUTO_TRUNCATE:-0}"      # 1 = --allow-auto-truncate


### PR DESCRIPTION
## The defect

Two separate mechanisms currently share one value:

```bash
CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-1024}"   # unconditional default
…
if (( CONTEXT_LENGTH > YARN_NATIVE_CTX )); then
  if (( CHUNKED_PREFILL_SIZE > 1024 )); then
    warn "… froze GB10 at 300k history — clamping to 1024"
```

**The clamp is right and this PR does not touch it.** Above native context a
4096 chunk froze GB10 at 300k history; 1024 is the safe value and it should stay
enforced.

The **unconditional default** is the problem. `CONTEXT_LENGTH=262144` is a
documented, supported configuration — it is the opt-out this repo tells you to
use (`CHANGELOG`: "Opt out with `CONTEXT_LENGTH=262144`"), and it is the only
option at all if you want bf16 or fp8 KV, since a bf16 pool at 1M now trips the
issue #8 pool guard and refuses to boot. Anyone taking that opt-out silently
inherits a chunk size chosen for a hazard that does not exist at native context,
and pays real prefill throughput for it.

`start.sh`'s own recorded provenance already disagrees with its default —
the model card recipe it follows, quoted in the header:

```
#   * Model card serving recipe (validated TP=2 on GB300/B300):
#     --quantization modelopt_fp4, --page-size 64, mamba extra_buffer +
#     --mamba-track-interval 64, --chunked-prefill-size 4096,
#     --mem-fraction-static 0.80, --context-length 262144, --allow-auto-truncate.
```

4096 at `--context-length 262144`. The 1M default arrived and took the chunk
size down with it for every context.

## What it costs

2× GB10 TP2, native 262,144 context, same pair, same harness, one variable
moved, medians of 2 measured reps (reps tight on both sides):

| prompt | chunk 1024 | chunk 4096 | |
|---|---:|---:|---|
| 8K | 2,439 tok/s | **2,799 tok/s** | **+15%** |
| 32K | 2,435 tok/s | **2,823 tok/s** | **+16%** |
| 128K | 2,065 tok/s | **2,548 tok/s** | **+23%** |

The shape is what you would expect: the smaller chunk multiplies scheduler
steps, and the penalty grows with prompt length.

Second-order but worth knowing, since it is the same knob: a small chunk at a
long prompt is also what widens the `/metrics` handler's blocking window. On a
128K prefill we measured 62–77 s of scheduler churn at chunk 1024 versus ~52 s
before, which was long enough for a 10 s metrics scrape to time out and take the
backend briefly out of a router's rotation.

## Why 4096 and not higher

An earlier sweep of ours at native context found **4096 / 8192 / 12288
statistically indistinguishable** — prefill within 1% above 8K, decode 250.0 vs
245.0 aggregate at c=16 against a **±8% run-to-run noise floor** (six repeats,
config held fixed). So 4096 is the *bottom* of a measured-equivalent band, not
the maximum. Deliberately conservative: it restores the throughput, it matches
the model card, and it keeps the smallest activation footprint of the three (the
larger values also give back a little KV pool — 623,936 tokens at 8192 vs
602,176 at 12288 — which is a reason not to reach for the top of the band).

## The change

- Default `CHUNKED_PREFILL_SIZE` **per context**: 4096 when
  `CONTEXT_LENGTH <= YARN_NATIVE_CTX`, 1024 above it. The 1M default path is
  bit-for-bit unchanged.
- An explicit `CHUNKED_PREFILL_SIZE` (shell or `.env`) still wins, and is still
  clamped above native context with the existing warning.
- `.env.example`, the `--help` header block, and the CHANGELOG line that
  currently reads "default **1024**" updated to match.

## Validation

`bash -n start.sh` clean. Full truth table, driven through the real assignment
and the real clamp block out of the patched script:

```
CONTEXT_LENGTH=1048576  CHUNKED_PREFILL_SIZE=unset  -> chunk=1024          (unchanged)
CONTEXT_LENGTH=262144   CHUNKED_PREFILL_SIZE=unset  -> chunk=4096          (the fix)
CONTEXT_LENGTH=131072   CHUNKED_PREFILL_SIZE=unset  -> chunk=4096
CONTEXT_LENGTH=1048576  CHUNKED_PREFILL_SIZE=8192   -> [WARN] … clamping to 1024
                                                       chunk=1024          (clamp intact)
CONTEXT_LENGTH=262144   CHUNKED_PREFILL_SIZE=8192   -> chunk=8192          (override honoured)
CONTEXT_LENGTH=262144   CHUNKED_PREFILL_SIZE=1024   -> chunk=1024          (override honoured)
unset                   unset                       -> ctx=1048576 chunk=1024
```

Beyond the A/B: the value this PR proposes as the native-context default is what
we already run in production. One of our pairs serves continuously at
`CONTEXT_LENGTH=262144` + `CHUNKED_PREFILL_SIZE=4096`, carried as a local `.env`
override against this recipe — `/get_server_info` on it right now reports
`context_length=262144`, `chunked_prefill_size=4096`,
`max_total_num_tokens=1907264`, `kv_cache_dtype=nvfp4`. It is stable there; the
override is the only reason it is not at 1024.
