### PR TITLE
fix(kv-eval): flush the prefix cache between cases, and make --seed actually vary the haystack

### DIFF
--- a/evals/nvfp4_kv_eval.py
+++ b/evals/nvfp4_kv_eval.py
@@ -10,6 +10,11 @@ Suites
   full   quick + 32k/64k NIAH (three positions each)
   long   full + 128k (GB10-safe with chunk 1024; do not raise further)
 
+The prefix cache is flushed before every case (POST /flush_cache), so a case
+cannot be answered out of the radix cache instead of out of attention. Pass
+--no-flush to measure with the cache warm; the JSON report records which it was.
+--seed salts the filler, so two seeds share no byte of haystack.
+
 Usage
   python3 evals/nvfp4_kv_eval.py
   python3 evals/nvfp4_kv_eval.py --suite full --json kv-eval.json
@@ -84,6 +89,7 @@ class CaseResult:
     prefill_tps: Optional[float]
     decode_tps: Optional[float]
     cache_hit: Optional[str] = None
+    cache_flushed: Optional[bool] = None
     error: Optional[str] = None
 
 
@@ -209,17 +215,37 @@ def metric_snapshot(base: str) -> dict[str, float]:
         return {}
 
 
+def flush_cache(base: str) -> tuple[bool, str]:
+    """Drop the radix/prefix cache. Single-stream, so nothing is in flight."""
+    try:
+        with _http_json(f"{base}/flush_cache", payload={}, timeout=60) as resp:
+            return True, resp.read().decode(errors="replace").strip()[:200]
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
 def make_passkey(rng: random.Random) -> str:
     parts = ["".join(rng.choice(ALPHABET) for _ in range(4)) for _ in range(3)]
     return "-".join(parts)
 
 
+# Salt for the filler, drawn from the run's rng in run(). Without it filler_line
+# is a pure function of the line index, so every run at a given depth sends a
+# byte-identical haystack and --seed only moves the needle.
+_FILLER_SALT = ""
+
+
+def set_filler_salt(salt: str) -> None:
+    global _FILLER_SALT
+    _FILLER_SALT = salt
+
+
 def filler_line(i: int) -> str:
-    adj = ADJECTIVES[i % len(ADJECTIVES)]
-    noun = NOUNS[i % len(NOUNS)]
-    serial = hashlib.md5(str(i).encode()).hexdigest()[:8]
+    h = hashlib.md5(f"{_FILLER_SALT}:{i}".encode()).hexdigest()
+    adj = ADJECTIVES[int(h[8:10], 16) % len(ADJECTIVES)]
+    noun = NOUNS[int(h[10:12], 16) % len(NOUNS)]
     return (
-        f"Record {i:06d}: crate {adj}-{noun} serial {serial} sits idle "
+        f"Record {i:06d}: crate {adj}-{noun} serial {h[:8]} sits idle "
         "and is unrelated to any passkey or secret code.\n"
     )
 
@@ -481,6 +507,7 @@ def case_from_chat(
     position: Optional[float],
     extra_text: str = "",
     cache_hit: Optional[str] = None,
+    cache_flushed: Optional[bool] = None,
     error: Optional[str] = None,
 ) -> CaseResult:
     blob = combined_text(result) + (" " + extra_text if extra_text else "")
@@ -500,6 +527,7 @@ def case_from_chat(
         prefill_tps=result.get("prefill_tps"),
         decode_tps=result.get("decode_tps"),
         cache_hit=cache_hit,
+        cache_flushed=cache_flushed,
         error=error,
     )
 
@@ -515,6 +543,25 @@ def run(args: argparse.Namespace) -> int:
         temperature=0.0,
     )
     rng = random.Random(args.seed)
+    # Salt the filler from the same rng: same seed → same prompt (reproducible),
+    # different seed → a haystack that shares no byte with the last one.
+    filler_salt = f"{rng.getrandbits(64):016x}"
+    set_filler_salt(filler_salt)
+
+    flush_on = not args.no_flush
+    flush_state = {"on": flush_on, "count": 0, "failed": 0}
+
+    def flush(label: str) -> Optional[bool]:
+        """Flush the prefix cache before a case, so it is answered by attention."""
+        if not flush_on:
+            return None
+        done, note = flush_cache(client.base)
+        flush_state["count"] += 1
+        if not done:
+            flush_state["failed"] += 1
+            print(_color(color, "1;33",
+                         f"  WARNING: /flush_cache failed before {label}: {note}"))
+        return done
 
     print(_color(color, "1;37", f"NVFP4 KV eval  { _utc() }"))
     print(f"  endpoint  {client.base}")
@@ -530,6 +577,13 @@ def run(args: argparse.Namespace) -> int:
     )
     if pool.context_length:
         print(f"  context   {pool.context_length}")
+    print(f"  seed      {args.seed}  (filler salt {filler_salt})")
+    if flush_on:
+        print("  cache     POST /flush_cache before every case (--no-flush to keep it warm)")
+    else:
+        print(_color(color, "1;33",
+                     "  cache     NOT flushed between cases — a case may be answered "
+                     "from the radix cache rather than from attention"))
     for note in pool.notes:
         print("  note     ", note)
 
@@ -599,6 +653,7 @@ def run(args: argparse.Namespace) -> int:
             print(f"         got      {got}")
 
     # --- control: needle only, no haystack (prompt/setup, not KV depth) ------
+    flushed = flush("control/no-haystack")
     code = make_passkey(rng)
     prompt = (
         f"The magic passkey is {code}.\n"
@@ -609,7 +664,7 @@ def run(args: argparse.Namespace) -> int:
         report(
             case_from_chat(
                 "control/no-haystack", "control", code, r, depth=r.get("prompt_tokens") or 0,
-                position=None,
+                position=None, cache_flushed=flushed,
             )
         )
     except Exception as exc:  # noqa: BLE001
@@ -632,15 +687,18 @@ def run(args: argparse.Namespace) -> int:
             )
         )
         print("control failed — not scoring retrieval (server/prompt issue)")
-        return _finish(args, pool, results, color, setup_failed=True)
+        return _finish(args, pool, results, color, setup_failed=True,
+                       filler_salt=filler_salt, flush=flush_state)
 
     # --- exact copy (decode path) --------------------------------------------
+    flushed = flush("decode/exact-copy")
     token = "NVFP4-OK-" + make_passkey(rng).split("-")[0]
     prompt = (
         f"Reply with exactly this string and nothing else: {token}\n"
     )
     r = client.complete([{"role": "user", "content": prompt}])
-    report(case_from_chat("decode/exact-copy", "decode", token, r, depth=0, position=None))
+    report(case_from_chat("decode/exact-copy", "decode", token, r, depth=0,
+                          position=None, cache_flushed=flushed))
 
     # --- NIAH ----------------------------------------------------------------
     for depth in depths:
@@ -655,11 +713,13 @@ def run(args: argparse.Namespace) -> int:
             code = make_passkey(rng)
             hay = haystack(n_lines, start, code, pos)
             name = f"niah/{depth}@{pos:.0%}"
+            flushed = flush(name)
             try:
                 r = client.complete([{"role": "user", "content": ask_passkey(hay)}])
                 report(
                     case_from_chat(
-                        name, "niah", code, r, depth=depth, position=pos
+                        name, "niah", code, r, depth=depth, position=pos,
+                        cache_flushed=flushed,
                     )
                 )
             except Exception as exc:  # noqa: BLE001
@@ -678,6 +738,7 @@ def run(args: argparse.Namespace) -> int:
                         ttft_s=None,
                         prefill_tps=None,
                         decode_tps=None,
+                        cache_flushed=flushed,
                         error=str(exc),
                     )
                 )
@@ -685,6 +746,7 @@ def run(args: argparse.Namespace) -> int:
     # --- multi-fact binding at ~8k ------------------------------------------
     bind_depth = 8192 if 8192 <= max(depths) or args.suite != "quick" else 4096
     if bind_depth <= max(depths) or args.suite != "quick":
+        flushed = flush("binding/port-kestrel")
         n_lines = est.lines_for(min(bind_depth, max(depths)))
         start = rng.randint(10_000, 80_000)
         lines = [filler_line(start + i) for i in range(n_lines)]
@@ -710,10 +772,15 @@ def run(args: argparse.Namespace) -> int:
                 r,
                 depth=bind_depth,
                 position=0.15,
+                cache_flushed=flushed,
             )
         )
 
     # --- radix follow-up: retrieve on turn 2 after a cached prefix ------------
+    # Flush before turn 1 and NOT between the turns: this case exists to test
+    # retrieval *out of* the cached prefix, so flushing mid-case would delete the
+    # thing under test. Everything before it starts from a cold cache.
+    flushed = flush("radix/follow-up")
     rad_depth = 4096 if 4096 in depths else depths[min(1, len(depths) - 1)]
     n_lines = est.lines_for(rad_depth)
     start = rng.randint(10_000, 80_000)
@@ -753,12 +820,14 @@ def run(args: argparse.Namespace) -> int:
             position=0.5,
             extra_text="",
             cache_hit=cache_note,
+            cache_flushed=flushed,
         )
     )
     if cache_note:
         print(f"         {cache_note}")
 
-    return _finish(args, pool, results, color, setup_failed=False)
+    return _finish(args, pool, results, color, setup_failed=False,
+                   filler_salt=filler_salt, flush=flush_state)
 
 
 def _fmt(v: Optional[float]) -> str:
@@ -776,6 +845,8 @@ def _finish(
     color: bool,
     *,
     setup_failed: bool,
+    filler_salt: str = "",
+    flush: Optional[dict[str, Any]] = None,
 ) -> int:
     niah = [c for c in results if c.kind == "niah"]
     niah_pass = sum(1 for c in niah if c.passed)
@@ -788,6 +859,15 @@ def _finish(
     print(f"  pool     dtype={pool.kv_cache_dtype}  nvfp4={pool.nvfp4}  "
           f"tokens={_fmt(pool.max_total_num_tokens)}  mem={_fmt(pool.kv_cache_memory_gb)} GB")
     print(f"  cases    {sum(c.passed for c in results)}/{len(results)} passed")
+    if flush is not None:
+        if flush["on"]:
+            note = f"flushed before {flush['count']} case(s)"
+            if flush["failed"]:
+                note += f" — {flush['failed']} /flush_cache call(s) FAILED"
+            print(f"  cache    {note}")
+        else:
+            print("  cache    NOT flushed — a case may have been served from the "
+                  "radix cache")
     if niah:
         print(f"  niah     {niah_pass}/{len(niah)} passed")
         for depth in sorted(by_depth):
@@ -833,6 +913,9 @@ def _finish(
         "started": _utc(),
         "endpoint": args.base_url,
         "suite": args.suite,
+        "seed": args.seed,
+        "filler_salt": filler_salt,
+        "cache_flush": flush,
         "pool": asdict(pool),
         "verdict": verdict,
         "why": why,
@@ -858,7 +941,15 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     p.add_argument("--positions", help="comma-separated fractions 0-1 (default 0,0.5,1)")
     p.add_argument("--timeout", type=float, default=1800.0, help="per-request seconds")
     p.add_argument("--max-tokens", type=int, default=64)
-    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--seed", type=int, default=7,
+                   help="salts the filler and the passkeys; two seeds share no "
+                        "byte of haystack")
+    p.add_argument(
+        "--no-flush",
+        action="store_true",
+        help="do not POST /flush_cache between cases — a case may then be "
+             "answered from the radix cache instead of from attention",
+    )
     p.add_argument("--thinking", action="store_true", help="leave Qwen thinking on")
     p.add_argument(
         "--require-nvfp4",


### PR DESCRIPTION
Two small independent changes to `evals/nvfp4_kv_eval.py`. Both are about making
the verdict mean what it says; neither changes what a case asks the model.

---

## 1. `--seed` did not change the prompt

`filler_line(i)` is a pure function of the line index:

```python
def filler_line(i: int) -> str:
    adj = ADJECTIVES[i % len(ADJECTIVES)]
    noun = NOUNS[i % len(NOUNS)]
    serial = hashlib.md5(str(i).encode()).hexdigest()[:8]
```

and `haystack()` builds from `filler_line(start + i)`. The only thing the rng
touches is the passkey. So **`--seed` moves the needle and leaves the haystack
byte-identical** — and the haystack is the part attention has to traverse.

Measured on `main`, three seeds, same depth and position, hashing the prompt with
the needle line removed:

```
seed 1: needle A6J9-ZWYS-F8Z3   whole-prompt sha c8e589878cb88aaa   filler-only sha 88c7ccc87256c01d
seed 2: needle 577R-CMJF-4CVT   whole-prompt sha e003e87657a35eb2   filler-only sha 88c7ccc87256c01d
seed 7: needle NBT5-68R5-F47V   whole-prompt sha 369b0bd504e88504   filler-only sha 88c7ccc87256c01d
```

**Fix:** salt the filler from the run's own rng. Same seed still reproduces the
same prompt exactly — that property is worth keeping — but two seeds now share no
byte of haystack. After:

```
seed 1: salt 91b7584a2265b1f5  filler-only sha 4c1cc4152f7bcd63
seed 2: salt dcf4bb99f4bea973  filler-only sha 02852fb4c87987d7
seed 7: salt f2a74de452e6b438  filler-only sha f2ceb0ef556505e6
seed 1: salt 91b7584a2265b1f5  filler-only sha 4c1cc4152f7bcd63   <- reproducible
```

The line shape is unchanged (`Record %06d: crate <adj>-<noun> serial <8 hex> …`),
so the token-per-line calibration behaves the same. The salt is printed in the
header and written to the JSON report, so a run stays auditable.

---

## 2. Nothing flushed the prefix cache between cases

`POST /flush_cache` is never called, and no case records whether the cache was
cold. With the radix cache on, a case whose prompt shares a prefix with an
earlier one — or a re-run of the same suite — can be answered **without
prefilling the haystack at all**, which is the thing the eval exists to measure.

How large the effect is, measured on a live 2× GB10 TP2 pair at native context,
NVFP4 KV, one 16,448-token prompt sent three times:

```
flush -> Cache flushed.
1 COLD (just flushed)                prompt=16448 tok    6.00s    2,743 tok/s  cache_hit_rate=0.0
2 WARM (identical prompt, no flush)  prompt=16448 tok    0.23s   72,008 tok/s  cache_hit_rate=0.996
flush -> Cache flushed.
3 COLD AGAIN (after flush)           prompt=16448 tok    5.40s    3,047 tok/s  cache_hit_rate=0.0
```

**26× faster and a 99.6% hit rate** — request 2 did not traverse the haystack in
any meaningful sense. Request 3 shows the flush restoring cold behaviour, so this
is causal, not drift.

That is a large enough effect that I think it is worth being explicit about what
it means for the result already in the CHANGELOG:

> Quick suite on this cluster (2026-08-27): **RELIABLE through 128k as a single
> huge prompt** (0/50/100%). 64k and 128k NIAH were 3/3 at every position.

I am **not** suggesting that result is wrong — it reproduced independently on my
own cluster, which is why I trust the eval enough to send patches for it. The
narrower point is that the script does not flush and does not log cache state, so
for any individual case in that run there is no longer a way to tell from the
record whether it was served cold or served from a prefix. That is unknowable
after the fact, and it need not be: one POST per case makes the same verdict
verifiable instead of merely reproducible.

**Fix:** `POST /flush_cache` before every case; `--no-flush` keeps the old
behaviour; per-case `cache_flushed` and an aggregate `cache_flush` block go into
the JSON report and the summary line.

One deliberate exception, commented in place: **the radix follow-up case flushes
before turn 1 and never between its turns.** Retrieval out of a cached prefix is
exactly what that case is for, so flushing mid-case would delete the thing under
test.

---

## Validation

`python3 -c "import ast; ast.parse(...)"` and `py_compile` clean; `--help`
renders. The seed hashes above are from importing both versions of the module
side by side and comparing.

Live, against a keyed 2× GB10 TP2 pair — native 262,144 context,
`kv_cache_dtype=nvfp4`, pool 1,907,264 tokens — four `quick` runs back to back:

| run | args | prompts | flushes | verdict |
|---|---|---|---|---|
| A | `--seed 1` | seed-1 haystack | 11/11 | RELIABLE-RETRIEVAL (niah 7/7) |
| B | `--seed 1 --no-flush` | identical to A | 0 | RELIABLE-RETRIEVAL (niah 7/7) |
| C | `--seed 1` | identical to A | 11/11 | DEGRADED (niah 4/7) |
| D | `--seed 2` | **different** haystack | 11/11 | UNRELIABLE (niah 1/7) |

Seed 2 lands on different prompt sizes, which is the change in §1 working
end-to-end rather than only in a unit test: `1104 / 4187 / 4187 / 4191 / 16433 /
16436 / 16436` prompt tokens against seed 1's `1105 / 4156 / 4155 / 4157 / 16315
/ 16315 / 16316`.

Header and summary lines, from run A:

```
  seed      1  (filler salt 91b7584a2265b1f5)
  cache     POST /flush_cache before every case (--no-flush to keep it warm)
  …
  cases    9/11 passed
  cache    flushed before 11 case(s)
```

and with `--no-flush`:

```
  cache     NOT flushed between cases — a case may be answered from the radix cache rather than from attention
  …
  cache    NOT flushed — a case may have been served from the radix cache
```

### One thing I should flag, because it is visible in that table

A and C sent **byte-identical prompts with identical flushing** and disagreed
(7/7 vs 4/7). Every one of the **16 failing cases across all four runs was the
token-0 `!` loop** — `!!!!!!…` instead of an answer, 16/16, no other failure mode
at all. That is the fault #6 is aimed at, it is intermittent on this hardware,
and it is orthogonal to this PR: it is not introduced by these changes, they do
not fix it, and it fires the same way with and without flushing.

I mention it only because it is the second reason a single run's verdict is not a
measurement on this stack, and it is the same remedy — record the conditions with
the result. If it would help I am happy to file that intermittency separately
with the per-case JSON attached; I did not want to bundle it into a patch about
something else.

No serving process was restarted or reconfigured for any of this; the runs are
ordinary inference load plus one `POST /flush_cache` per case, and every prompt
was ≤ 16.5k tokens.
