### PR TITLE
fix(weights): verify indexed shards offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this serving recipe.
 
 ### Fixed
 
+- Offline weight verification now reads the safetensors index instead of
+  assuming at least 400 shards; the model has 206 shards, so a transient HF
+  API outage no longer triggers an unnecessary 135 GB re-download.
 - **SM121 QSA decode token-id-0** ([sglang#36537](https://github.com/sgl-project/sglang/issues/36537),
   [sglang#36806](https://github.com/sgl-project/sglang/pull/36806),
   [sglang#36845](https://github.com/sgl-project/sglang/pull/36845)). FlashInfer

--- a/start.sh
+++ b/start.sh
@@ -1640,12 +1640,24 @@ try:
         files = [(s["rfilename"], s.get("size") or 0) for s in json.load(r)["siblings"]]
 except Exception as e:
     print(f"[WARN]  HF API unreachable ({e}); falling back to heuristic check")
-    need = ("config.json", "model.safetensors.index.json")
-    st = sum(1 for f in os.listdir(snap) if f.endswith(".safetensors"))
-    if all(os.path.exists(os.path.join(snap, n)) for n in need) and st >= 400:
-        print(f"[OK]    {label}: heuristic check passed ({st} safetensors)")
+    index_path = os.path.join(snap, "model.safetensors.index.json")
+    try:
+        with open(index_path) as f:
+            shards = set(json.load(f)["weight_map"].values())
+    except (OSError, KeyError, TypeError, json.JSONDecodeError):
+        shards = set()
+    missing_shards = [
+        name for name in shards
+        if not os.path.isfile(os.path.join(snap, name))
+        or os.path.getsize(os.path.join(snap, name)) == 0
+    ]
+    if os.path.isfile(os.path.join(snap, "config.json")) and shards and not missing_shards:
+        print(f"[OK]    {label}: heuristic check passed ({len(shards)} indexed shards)")
         sys.exit(0)
-    print(f"[ERROR] {label}: heuristic check failed ({st} safetensors)")
+    print(
+        f"[ERROR] {label}: heuristic check failed "
+        f"({len(shards)} indexed shards, {len(missing_shards)} missing/empty)"
+    )
     sys.exit(1)
 missing, bad = [], []
 for name, size in files:


### PR DESCRIPTION
## Summary

- use `model.safetensors.index.json` as the offline source of truth
- verify every indexed shard exists and is non-empty
- avoid a redundant 135 GB download when the Hugging Face API is temporarily unavailable

The current fallback requires at least 400 safetensors, but this checkpoint has 206 indexed shards, so a complete local snapshot is rejected during an API outage.

## Verification

- `bash -n start.sh`
- forced the verifier's API request to a closed localhost port
- complete 206-shard snapshot passes
- synthetic snapshot with one missing indexed shard fails
- live two-node startup accepted both cached snapshots during an actual Hugging Face SSL failure