### PR TITLE
start.sh: honor the documented env knobs on both ranks + JSON override hooks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -64,6 +64,10 @@ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-auto}"   # auto = model dtype (bf16); this che
 PLE_OFFLOAD="${PLE_OFFLOAD:-false}"
 EXTRA_VLLM_ARGS="${EXTRA_VLLM_ARGS:-}"
 EXTRA_DOCKER_ARGS="${EXTRA_DOCKER_ARGS:-}"
+# Optional JSON overrides: full --speculative-config JSON (empty = MTP with
+# MTP_NUM_SPECULATIVE_TOKENS, 0 = off) and the --compilation-config JSON.
+SPEC_CONFIG_JSON="${SPEC_CONFIG_JSON:-}"
+if [[ -z "${COMPILATION_CONFIG_JSON:-}" ]]; then COMPILATION_CONFIG_JSON='{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}'; fi
 HF_TOKEN="${HF_TOKEN:-}"
 
 # YaRN only makes sense ABOVE the native 262144 context. At or below native,
@@ -473,6 +477,19 @@ else:
     PLE_OFFLOAD_ENV=""
     [[ "$PLE_OFFLOAD" == "true" ]] && PLE_OFFLOAD_ENV="-e VLLM_PLE_CPU_OFFLOAD=1"
 
+    # Resolve the engine-arg fragments shared by BOTH ranks (TP ranks must match).
+    EP_ARGS=""
+    [[ "$ENABLE_EXPERT_PARALLEL" == "true" ]] && EP_ARGS="--enable-expert-parallel --all2all-backend allgather_reducescatter"
+    if [[ -n "$SPEC_CONFIG_JSON" ]]; then
+        SPEC_ARGS="--speculative-config '$SPEC_CONFIG_JSON'"
+    elif [[ "$MTP_NUM_SPECULATIVE_TOKENS" -gt 0 ]]; then
+        SPEC_ARGS="--speculative-config '{\"method\":\"mtp\",\"num_speculative_tokens\":$MTP_NUM_SPECULATIVE_TOKENS}'"
+    else
+        SPEC_ARGS=""
+    fi
+    COMPILE_ARGS="--compilation-config '$COMPILATION_CONFIG_JSON'"
+    info "  engine fragments: EP=[$EP_ARGS] SPEC=[$SPEC_ARGS] COMPILE=[$COMPILE_ARGS] EXTRA=[$EXTRA_VLLM_ARGS] DOCKER_EXTRA=[$EXTRA_DOCKER_ARGS]"
+
     # Write worker launch script to a temp file and scp it (avoids SSH JSON quoting issues)
     WORKER_SCRIPT=$(mktemp /tmp/vllm_worker_XXXXXX.sh)
     cat > "$WORKER_SCRIPT" <<LAUNCH_EOF
@@ -482,6 +499,7 @@ docker run \
     --gpus all --network host --ipc host \
     --cap-add SYS_NICE --ulimit memlock=-1 --ulimit stack=67108864 \
     --device /dev/infiniband:/dev/infiniband \
+    $EXTRA_DOCKER_ARGS \
     -e GLOO_SOCKET_IFNAME=$WORKER_IFACE \
     -e NCCL_SOCKET_IFNAME=$WORKER_IFACE \
     -e TP_SOCKET_IFNAME=$WORKER_IFACE \
@@ -519,10 +537,10 @@ docker run \
     --nnodes 2 \
     --master-addr $HEAD_IP \
     --master-port $MASTER_PORT \
-    --enable-expert-parallel \
-    --all2all-backend allgather_reducescatter \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":$MTP_NUM_SPECULATIVE_TOKENS}' \
-    --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    $EP_ARGS \
+    $SPEC_ARGS \
+    $COMPILE_ARGS \
+    $EXTRA_VLLM_ARGS \
     --node-rank 1 \
     --headless
 LAUNCH_EOF
@@ -556,6 +574,7 @@ docker run \
     --gpus all --network host --ipc host \
     --cap-add SYS_NICE --ulimit memlock=-1 --ulimit stack=67108864 \
     --device /dev/infiniband:/dev/infiniband \
+    $EXTRA_DOCKER_ARGS \
     -e GLOO_SOCKET_IFNAME=$IFACE \
     -e NCCL_SOCKET_IFNAME=$IFACE \
     -e TP_SOCKET_IFNAME=$IFACE \
@@ -593,10 +612,10 @@ docker run \
     --nnodes 2 \
     --master-addr $HEAD_IP \
     --master-port $MASTER_PORT \
-    --enable-expert-parallel \
-    --all2all-backend allgather_reducescatter \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":$MTP_NUM_SPECULATIVE_TOKENS}' \
-    --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    $EP_ARGS \
+    $SPEC_ARGS \
+    $COMPILE_ARGS \
+    $EXTRA_VLLM_ARGS \
     --node-rank 0 \
     --host 0.0.0.0 \
     --port $PORT


### PR DESCRIPTION
First off — thank you for this recipe. We run it in production on a dgx6+dgx2 pair and it's been rock solid.

## The bug

The launch heredocs hardcode `--enable-expert-parallel`, the MTP speculative config, and the mode-0 compilation config on both ranks, so several env knobs the script defines are silently ignored: `ENABLE_EXPERT_PARALLEL=false`, `MTP_NUM_SPECULATIVE_TOKENS=0`, `EXTRA_VLLM_ARGS`, and `EXTRA_DOCKER_ARGS` all no-op. We only noticed when an A/B we thought we were running turned out to be two identical launches.

## The fix

Both ranks now build identical engine-arg fragments from the env (resolved once, logged at launch so you can see what actually applied). Defaults preserve current behavior exactly — a stock `.env` produces the same `vllm serve` line as before.

Two new optional knobs, both defaulting to current behavior:
- `SPEC_CONFIG_JSON` — full `--speculative-config` JSON, for fields beyond `num_speculative_tokens` (e.g. `index_share_for_mtp_iteration`)
- `COMPILATION_CONFIG_JSON` — full `--compilation-config` JSON

One gotcha baked into the patch: the compile default uses an if-guard rather than `${VAR:-{json}}`, because bash ends that expansion at the first unescaped `}` and ships a trailing brace to `vllm serve` (we hit this in the wild).

## Why you might care

With these knobs working we ran a one-variable-at-a-time sweep on our pair and got single-stream decode from ~59 to **68.5 tok/s** (counting bench, temp 1.0) on top of your recipe — MTP `num_speculative_tokens: 4` + `index_share_for_mtp_iteration: true` + `--async-scheduling` (via `EXTRA_VLLM_ARGS`), plus disabling CPU C-states. Full numbers in the companion issue.

Tested on: 2× DGX Spark (GB10), TP2 over RoCE, native 262k, the stock container image. Happy to adjust style/naming to whatever you prefer.