### PR TITLE
Uncensored mode with custom-quant PLE from orcarouter

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,8 +21,25 @@ IB_HCA="=rocep1s0f0"                   # Single device, exact match (leading =)
 IB_GID_INDEX=3                          # Usually 3 on ConnectX with RoCE
 
 # -- Model ---------------------------------------------------------------------
+# THE RECIPE SWITCH — one line selects the checkpoint. Compatible builds:
+#   "RadixArk/Qwen3.8-Flash-Next-NVFP4"   (default) — the build this recipe targets
+#   "lychee888/Qwen3.8-Flash-Next-Uncensored-NVFP4-FP8PLE"
+#       — orca's abliterated build with the PLE n-gram table FP8-quantized
+#         (RadixArk-compatible PLE layout; 123.25 GiB; public).
+#   "orcarouter/Qwen3.8-Flash-Next-Uncensored-NVFP4"
+#       — orca's abliterated build, PLE kept bf16 (170.93 GiB; GATED: request
+#         access at huggingface.co and set HF_TOKEN below).
+#   "/absolute/path/to/model/dir" — local flat repo dir staged on both nodes
+#       (skips HF download + worker rsync; bind-mounted read-only). The path
+#       must resolve on both nodes (shared/NFS or identical staging).
 MODEL_ID="RadixArk/Qwen3.8-Flash-Next-NVFP4"
-SERVED_MODEL_NAME="qwen3.8-flash-next"
+SERVED_MODEL_NAME="qwen3.8-flash-next"          # for the orca-derived builds use "qwen3.8-flash-next-uncensored"
+
+# -- PLE quant override (optional) ---------------------------------------------
+# start.sh auto-derives this from the model's config.json
+# (text_config.ple_embedding_dtype: float8_e4m3fn -> fp8, absent/bf16 -> bf16).
+# Set explicitly only to override the auto-detection.
+# PLE_QUANT_OVERRIDE="fp8"
 
 # -- Serving Parameters --------------------------------------------------------
 MAX_MODEL_LEN=1000000                    # YaRN 1M context
@@ -62,6 +79,6 @@ PLE_OFFLOAD=false                       # Set true to offload 51B PLE table to C
 # -- Advanced ------------------------------------------------------------------
 # EXTRA_VLLM_ARGS=""
 # EXTRA_DOCKER_ARGS=""
-# HF_TOKEN=""
+# HF_TOKEN=""                            # needed only for gated repos (e.g. the orcarouter builds)
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1         # Required when MAX_MODEL_LEN > 262144 (YaRN)
 MASTER_PORT=50000                       # NCCL/distributed coordination port

--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
 <h1 align="center">Qwen3.8-Flash-Next-NVFP4-vLLM-Dual-DGX-Spark</h1>
 
 <p align="center">
-  <sub>by <a href="https://x.com/MiaAI_lab">Mia'a AI Lab</a></sub>
+  <sub>by <a href="https://x.com/MiaAI_lab">Mia'a AI Lab</a> · forked by <a href="https://github.com/jarvis959">jarvis959</a></sub>
   <br><br>
   <a href="https://github.com/sponsors/MiaAI-Lab" target="_blank" rel="noopener noreferrer" style="display:inline-block;margin:0 8px;vertical-align:middle;"><img src="https://img.shields.io/badge/Sponsor%20me%20on%20GitHub-181717?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sponsor me on GitHub" height="28" style="height:28px;width:auto;vertical-align:middle;border:0;" /></a>
   <a href="https://x.com/MiaAI_lab" target="_blank" rel="noopener noreferrer" style="display:inline-block;margin:0 8px;vertical-align:middle;"><img src="https://img.shields.io/badge/Follow%20me%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow Mia on X" height="28" style="height:28px;width:auto;vertical-align:middle;border:0;" /></a>
 </p>
 
-Multi-node inference for [RadixArk/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/RadixArk/Qwen3.8-Flash-Next-NVFP4) across 2 DGX Sparks using vLLM with TP2+EP+MTP3.
+Multi-node inference for Flash-Next NVFP4 checkpoints across 2 DGX Sparks using vLLM with TP2+EP+MTP3 — targets [RadixArk/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/RadixArk/Qwen3.8-Flash-Next-NVFP4) by default and can switch to compatible builds with one `MODEL_ID` line; see [Recipe switching](#recipe-switching).
 
 Based on [getrefined/Qwen3.8-Flash-Next-NVFP4-vLLM-DGX-Spark](https://github.com/getrefined/Qwen3.8-Flash-Next-NVFP4-vLLM-DGX-Spark).
 
-All numbers in **KV cache budget** and **Default runtime** below were read from the running
+All numbers in **KV cache budget** and **Default runtime** below were rea## Recipe switching
+
+Fork add-on: `start.sh` now auto-derives `PLE_QUANT_OVERRIDE` from the model's `config.json` (unset in `.env` = auto), so switching the served build is a single `MODEL_ID` line.
+
+**Auto-derivation:** when `PLE_QUANT_OVERRIDE` is unset, `start.sh` reads `text_config.ple_embedding_dtype` from the model's `config.json` (fetched from the HF API, using `HF_TOKEN` when set) and sets `fp8` for `float8_e4m3fn`, else `bf16`. The PLE resolver shim in `files/ple_layer_patched.py` activates only for `fp8`; `bf16` builds keep the stock loader. This replaces the previously hardcoded `PLE_QUANT_OVERRIDE=fp8`, which assumed the RadixArk build. The `MODEL_ID` value flows into the container as the vLLM model argument, so any build the pinned image supports works.
+
+Compatible checkpoints (2026-09):
+
+| `MODEL_ID` | PLE (auto) | Notes |
+|---|---|---|
+| `RadixArk/Qwen3.8-Flash-Next-NVFP4` | `fp8` | the default target of this recipe (125.91 GiB; public) |
+| `lychee888/Qwen3.8-Flash-Next-Uncensored-NVFP4-FP8PLE` | `fp8` | orca's abliterated build, PLE table FP8-quantized in the RadixArk PLE layout (123.25 GiB; public) |
+| `orcarouter/Qwen3.8-Flash-Next-Uncensored-NVFP4` | `bf16` | orca's abliterated build, PLE kept bf16 (170.93 GiB; gated: request access + `HF_TOKEN`) |
+
+All three carry identical MTP weights and the same `layer_types` (`full_attention` ×12 / `linear_attention` ×36), so the MTP3 speculative config applies unchanged. Set `SERVED_MODEL_NAME` to match the build (e.g. `qwen3.8-flash-next-uncensored` for the orca-derived ones). Pin `PLE_QUANT_OVERRIDE` in `.env` to override auto-detection if needed.
+
+d from the running
 server (`docker logs vllm-fn`, `docker inspect vllm-fn`) — they are measurements, not estimates.
 That container runs `GPU_MEMORY_UTILIZATION=0.835`, i.e. the value `.env` / `.env.sample` ship today.
 
@@ -87,6 +103,8 @@ every measurement in this README.
 | `IMAGE` | `vllm/vllm-openai:qwen38-flash-next` | same | Day-0 image |
 | `VLLM_ALLOW_LONG_MAX_MODEL_LEN` | `1` | `1` | Required when `MAX_MODEL_LEN` > 262144 |
 | `MASTER_PORT` | `50000` | `50000` | Distributed coordination port |
+| `PLE_QUANT_OVERRIDE` | unset (auto) | unset (auto) | optional pin; auto-derived from the model's `config.json` `ple_embedding_dtype` when unset |
+| `HF_TOKEN` | unset | unset | HuggingFace token, needed only for gated repos (e.g. the orcarouter builds) during download/auto-derive |
 | `EXTRA_VLLM_ARGS` / `EXTRA_DOCKER_ARGS` / `HF_TOKEN` | unset | unset | Escape hatches (`EXTRA_VLLM_ARGS` is appended last) |
 
 > **KV cache dtype:** the default is **`auto`, which resolves to bfloat16** (the engine logs

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # ============================================================================
-# start.sh — Download, distribute, and serve RadixArk/Qwen3.8-Flash-Next-NVFP4
+# start.sh — Download, distribute, and serve a Flash-Next NVFP4 checkpoint
 #             across a 2-node DGX Spark cluster with vLLM TP2+EP+MTP3.
+# Recipe-switching add-on: PLE_QUANT_OVERRIDE auto-derives from the model's
+# config.json (unset in .env = auto). See README "Recipe switching".
 #
 # Based on: https://github.com/getrefined/Qwen3.8-Flash-Next-NVFP4-vLLM-DGX-Spark
 #
@@ -65,6 +67,44 @@ PLE_OFFLOAD="${PLE_OFFLOAD:-false}"
 EXTRA_VLLM_ARGS="${EXTRA_VLLM_ARGS:-}"
 EXTRA_DOCKER_ARGS="${EXTRA_DOCKER_ARGS:-}"
 HF_TOKEN="${HF_TOKEN:-}"
+
+# ---------------------------------------------------------------------------
+# PLE quant override — auto-derives from the model's config.json unless
+# PLE_QUANT_OVERRIDE is set explicitly in .env.
+#   config text_config.ple_embedding_dtype == "float8_e4m3fn" -> fp8
+#   absent or bf16                                            -> bf16
+# The fp8 path activates the ple_layer resolver shim
+# (files/ple_layer_patched.py); the bf16 path leaves it installed but inert.
+# ---------------------------------------------------------------------------
+PLE_QUANT_OVERRIDE="${PLE_QUANT_OVERRIDE:-}"
+if [[ -z "$PLE_QUANT_OVERRIDE" ]]; then
+    ple_dtype=""
+    if [[ "$MODEL_ID" == /* ]]; then
+        ple_dtype=$(python3 -c "
+import json,sys
+try:
+    c=json.load(open(sys.argv[1]+'/config.json')); tc=c.get('text_config',c)
+    print(tc.get('ple_embedding_dtype') or '')
+except Exception:
+    print('')
+" "$MODEL_ID" 2>/dev/null)
+    else
+        ple_dtype=$(curl -sfL --max-time 15 -H "Authorization: Bearer ${HF_TOKEN:-}" \
+            "https://huggingface.co/${MODEL_ID}/resolve/main/config.json" 2>/dev/null | python3 -c "
+import json,sys
+try:
+    c=json.load(sys.stdin); tc=c.get('text_config',c)
+    print(tc.get('ple_embedding_dtype') or '')
+except Exception:
+    print('')
+" 2>/dev/null)
+    fi
+    case "$ple_dtype" in
+        float8_e4m3fn|fp8|f8_e4m3*) PLE_QUANT_OVERRIDE="fp8" ;;
+        *) PLE_QUANT_OVERRIDE="bf16" ;;
+    esac
+    echo "INFO: PLE_QUANT_OVERRIDE auto-derived as $PLE_QUANT_OVERRIDE from model config (ple_embedding_dtype='${ple_dtype:-<absent>}')"
+fi
 
 # YaRN only makes sense ABOVE the native 262144 context. At or below native,
 # rope scaling degrades quality for zero benefit — force it off.
@@ -415,7 +455,7 @@ else:
     DOCKER_ARGS+=(-e "HF_HUB_OFFLINE=1")
     DOCKER_ARGS+=(-e "TRANSFORMERS_OFFLINE=1")
     # PLE FP8 fix
-    DOCKER_ARGS+=(-e "PLE_QUANT_OVERRIDE=fp8")
+    DOCKER_ARGS+=(-e "PLE_QUANT_OVERRIDE=$PLE_QUANT_OVERRIDE")
     # YaRN: allow max_model_len > 262K
     if [[ -n "$VLLM_ALLOW_LONG_MAX_MODEL_LEN" ]]; then
         DOCKER_ARGS+=(-e "VLLM_ALLOW_LONG_MAX_MODEL_LEN=$VLLM_ALLOW_LONG_MAX_MODEL_LEN")
@@ -492,7 +532,7 @@ docker run \
     -e NCCL_DEBUG=WARN \
     -e HF_HUB_OFFLINE=1 \
     -e TRANSFORMERS_OFFLINE=1 \
-    -e PLE_QUANT_OVERRIDE=fp8 \
+    -e PLE_QUANT_OVERRIDE=$PLE_QUANT_OVERRIDE \
     -e VLLM_HOST_IP=$WORKER_IP \
     ${VLLM_ALLOW_LONG_MAX_MODEL_LEN:+-e VLLM_ALLOW_LONG_MAX_MODEL_LEN=$VLLM_ALLOW_LONG_MAX_MODEL_LEN} \
     $PLE_OFFLOAD_ENV \
@@ -566,7 +606,7 @@ docker run \
     -e NCCL_DEBUG=WARN \
     -e HF_HUB_OFFLINE=1 \
     -e TRANSFORMERS_OFFLINE=1 \
-    -e PLE_QUANT_OVERRIDE=fp8 \
+    -e PLE_QUANT_OVERRIDE=$PLE_QUANT_OVERRIDE \
     -e VLLM_HOST_IP=$HEAD_IP \
     ${VLLM_ALLOW_LONG_MAX_MODEL_LEN:+-e VLLM_ALLOW_LONG_MAX_MODEL_LEN=$VLLM_ALLOW_LONG_MAX_MODEL_LEN} \
     $PLE_OFFLOAD_ENV \


### PR DESCRIPTION
Hi Mia — thanks for the recipe, been running it on 2x DGX Spark.

This PR makes the PLE resolver override auto-derive instead of hardcoded `PLE_QUANT_OVERRIDE=fp8`, so a single `MODEL_ID` line in `.env` switches between compatible builds:

- `RadixArk/Qwen3.8-Flash-Next-NVFP4` (default, unchanged behavior) → `fp8`
- `lychee888/Qwen3.8-Flash-Next-Uncensored-NVFP4-FP8PLE` (orcarouter's abliterated build with the PLE n-gram table FP8-quantized in your PLE layout) → `fp8`
- `orcarouter/Qwen3.8-Flash-Next-Uncensored-NVFP4` (PLE kept bf16, 170.93 GiB, gated) → `bf16`

`start.sh` reads `text_config.ple_embedding_dtype` from the model's `config.json` (HF API, using `HF_TOKEN` when set; `float8_e4m3fn` → fp8, else bf16) unless `PLE_QUANT_OVERRIDE` is pinned in `.env`. All three builds share identical MTP weights and `layer_types`, so the MTP3 speculative config applies unchanged.

Verified on a live 2-node DGX Spark pair with the pinned image (`vllm/vllm-openai:qwen38-flash-next`):
- auto-derive: RadixArk config → `fp8` (matches today's hardcoded behavior), orca bf16 config → `bf16`, local FP8-PLE dir → `fp8`
- `bash -n` clean; `ple_layer_patched.py` shim untouched
- README gains a 'Recipe switching' section + `.env` table rows; `.env.sample` documents the switch

Happy to split or rebase if you'd prefer a smaller change. The FP8-PLE checkpoint docs (quantization details, RadixArk similarity) are at the [model card](https://huggingface.co/lychee888/Qwen3.8-Flash-Next-Uncensored-NVFP4-FP8PLE).
