### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug.md
+++ b/.github/ISSUE_TEMPLATE/1_bug.md
@@ -1,0 +1,98 @@
+---
+name: Bug report
+about: The model kit is not behaving as expected, is producing an error, or the numbers do not match the README.
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README and .env reference first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you have found a bug, then fill out the template below.
+-->
+
+---
+
+## Environment
+
+<!-- Fill in what applies to your setup. The README's ".env Reference" and "KV cache
+     budget" sections list the knobs that affect behavior, and the defaults shipped
+     in .env.sample. -->
+
+- Hardware / nodes: <!-- e.g. 2x DGX Spark (GB10, 128 GB unified memory), or 1x DGX Station, ... -->
+- Interconnect: <!-- e.g. ConnectX RoCE/IB, 10GbE, ... -->
+- Image / vLLM version: <!-- `docker images | grep vllm` or `docker inspect vllm-fn` -->
+- Model (`MODEL_ID`): <!-- e.g. RadixArk/Qwen3.8-Flash-Next-NVFP4 -->
+- `start.sh` flags used: <!-- e.g. `./start.sh --no-download --launch` -->
+- Relevant `.env` values: <!-- e.g. MAX_MODEL_LEN, KV_CACHE_DTYPE, GPU_MEMORY_UTILIZATION, TENSOR_PARALLEL_SIZE, MTP_NUM_SPECULATIVE_TOKENS, PLE_OFFLOAD -->
+
+---
+
+## Steps to Reproduce
+
+<!-- Please include full steps to reproduce so that we can reproduce the problem. -->
+
+1. Run `./start.sh` <!-- describe the flags and what it printed up to the failure -->
+2. ... <!-- describe steps to demonstrate bug -->
+3. ... <!-- for example "curl /v1/models returns a different served name than the one set in .env" -->
+
+**Expected results:** <!-- what did you expect to happen? -->
+
+**Actual results:** <!-- what did you actually see happen? -->
+
+---
+
+### Additional context
+
+Add any other context about the problem here: a minimal request to reproduce bad output, JSON responses, `docker inspect` output, and so on.
+
+<details>
+<summary>Minimal reproduction sample</summary>
+
+<!--
+      If the bug is about model output or API behavior, attach a minimal reproducible
+      request below between the lines with the backticks.
+-->
+
+```bash
+curl -s http://localhost:8888/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3.8-flash-next",
+    "messages": [{"role": "user", "content": "..."}],
+    "max_tokens": 256
+  }'
+```
+
+</details>
+
+<details>
+  <summary>Logs</summary>
+
+<!--
+      Paste the log output below between the lines with the backticks, and mention
+      whether it came from `start.sh`, `docker logs vllm-fn`, or a client.
+
+      Common culprits worth checking before filing:
+        * `CUDA out of memory` right after launch -> drop_caches was skipped or
+          GPU_MEMORY_UTILIZATION / MAX_NUM_SEQS are too high (see README "Gotchas").
+        * NCCL hanging mid-init -> IB_HCA points at a port cabled to another cluster.
+        * `kv_cache_dtype` mismatch -> this checkpoint only supports bf16 KV cache.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->

--- a/.github/ISSUE_TEMPLATE/2_improvement.md
+++ b/.github/ISSUE_TEMPLATE/2_improvement.md
@@ -1,0 +1,86 @@
+---
+name: Improvement proposal
+about: General improvements to the kit. Anything that exists and works, but could be enhanced or optimized.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README and .env reference first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you think something can be improved, then fill out the template below.
+-->
+
+---
+
+## Improvement description
+
+<!--
+      What is it that you think can be improved? Give a clear explanation of what
+      element can be done better and how the kit can benefit from it.
+
+      Examples that fit this repo: better KV cache budget / concurrency defaults,
+      faster startup, safer .env validation, clearer docs, a script to re-measure
+      performance after changing knobs, a benchmark harness, a change to how the
+      download -> rsync -> patch -> launch pipeline works, the PLE patch approach
+      (bind-mount vs image rebuild), how `.env` knobs map to vLLM flags, the
+      two-node TP/EP/MTP orchestration, and so on.
+-->
+
+---
+
+### Additional context
+
+Add any other context here: code snippets, measured numbers (e.g. TTFT / decode throughput before and after), `docker logs` excerpts, screenshots, and so on.
+
+<details>
+<summary>Code sample</summary>
+
+<!--
+      Attach a minimal code sample that demonstrates the improvement you have in mind,
+      below between the lines with the backticks.
+-->
+
+```bash
+
+```
+
+</details>
+
+<details>
+  <summary>Logs / measurements</summary>
+
+<!--
+      Paste any measured numbers or log output below between the lines with the
+      backticks, so the benefit of the change can be evaluated.
+-->
+
+```
+
+```
+
+</details>
+
+<details>
+  <summary>Screenshots</summary>
+
+<!--
+      Consider also attaching screenshots and/or videos to better illustrate the issue.
+
+      You can upload them directly on GitHub.
+      Beware that video file size is limited to 10MB.
+-->
+
+```
+
+```
+
+</details>
+
+<!--
+      Include any additional resource that doesn't fit the categories previously listed.
+-->

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Suggest a new idea for this kit. Something that doesn't exist currently, and you want to see.
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+<!-- Thank you for using this model kit!
+
+     If you are looking for support, please check the README and .env reference first,
+     or reach out on X:
+      * https://x.com/MiaAI_lab
+
+     If you want the kit to do something it currently doesn't, then fill out the
+     template below.
+-->
+
+## Use case
+
+<!--
+     Please tell us the challenge you are running into that led to you wanting
+     a new feature, or the workload you are trying to serve.
+
+     Examples that could fit this repo: single-node mode, an OpenAI-compatible
+     client example, a benchmark script, a systemd unit or compose file, support
+     for a different cluster topology, a lint/validate step in CI, and so on.
+
+     Describe the alternative solutions you've considered.
+-->
+
+## Proposal
+
+<!--
+     Briefly but precisely describe what you would like this kit to be able to do.
+
+     Consider attaching something showing what you are imagining:
+      * images
+      * videos
+      * code samples
+      * a benchmark result or log you are trying to reproduce
+
+     Does this have to be provided by this kit directly, or can it be a small
+     user-land script? If the latter, maybe consider implementing and sharing it
+     with us in a pull request rather than filing an issue.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: I want help using this model kit on my own hardware.
+    url: https://x.com/MiaAI_lab
+    about: Ask questions about setting this up on a different cluster, or about how a particular piece of this kit works.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+## Description and Motivation
+
+<!--
+
+    Please write a description of what this PR is changing, removing or adding, and why.
+    Consider including before/after comparisons.
+
+    For this kit, a good description usually covers:
+      * which .env knob or script behavior changes
+      * whether the change affects measured numbers (KV cache budget, TTFT, decode
+        throughput, concurrency) and, if so, the expected direction
+      * why the change is safe on both DGX Spark nodes
+
+-->
+
+## Related Issues
+
+<!--
+
+    Add the list of issues related to this PR from the [issue tracker](https://github.com/MiaAI-Lab/Qwen3.8-Flash-Next-Dual-DGX-Sparks/issues).
+    Indicate which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.
+
+-->
+
+---
+
+## Testing
+
+<!--
+
+    Tell us how you verified this change. For this kit that usually means:
+
+      * `bash -n start.sh stop.sh check-weights.sh` (syntax check)
+      * `shellcheck start.sh stop.sh check-weights.sh` if available
+      * an actual launch on the cluster: `./start.sh --no-download --launch` and the
+        resulting `docker logs vllm-fn 2>&1 | grep -E "Available KV cache memory|GPU KV cache size"`,
+        or at minimum a dry-run on a node you have
+      * if behavior changed, the measured numbers with the new settings (see README
+        "Performance" / "KV cache budget" for the format used)
+
+-->
+
+---
+
+## Checklist:
+
+<!--
+
+    Thanks for contributing to Mia's AI Lab!
+
+    Before you file this pull request, please follow the items on this checklist and
+    put an x in each of the boxes, like this: [x].
+
+-->
+
+- [ ] I have read the README and `.env.sample` and kept my changes consistent with them.
+- [ ] My pull request has a sound title and description (not something vague like `Update README.md`).
+- [ ] My change is reproducible and verified (e.g. script syntax check, a launch, or a re-measurement).
+- [ ] I updated the README and/or `.env.sample` if a `.env` knob, default, or measured number changed.
+- [ ] Defaults in `.env.sample` still work out of the box; a new knob has a sane fallback like the existing ones.


### PR DESCRIPTION
## Description

Adds GitHub issue templates and a pull request template to this repository. This is a new addition: the repo previously had no `.github` templates (only `FUNDING.yml`).

**Issue templates:**

- `1_bug.md` - Bug report. Includes an environment section (hardware, interconnect, image/vLLM version, `start.sh` flags, relevant `.env` knobs such as `MAX_MODEL_LEN`, `KV_CACHE_DTYPE`, `GPU_MEMORY_UTILIZATION`, `TENSOR_PARALLEL_SIZE`, `MTP_NUM_SPECULATIVE_TOKENS`, `PLE_OFFLOAD`), a reproducible `curl` sample matching the served model name and port from `.env.sample`, and common-culprit hints from the README "Gotchas" section (page cache drops, IB_HCA misconfig, bf16-only KV cache).
- `2_improvement.md` - Improvement proposal. Covers performance/config/defaults improvements as well as architecture-level changes (launch pipeline, PLE patch approach, TP/EP/MTP orchestration), with a place for measured numbers (TTFT, decode throughput, KV cache budget).
- `3_feature_request.md` - Feature request. Asks for the use case/workload first and suggests repo-fitting ideas (single-node mode, client examples, benchmark script, compose/systemd, CI additions).

Plus `config.yml` (blank issues enabled, contact link) and `PULL_REQUEST_TEMPLATE.md` with a checklist scoped to what this repo can actually do: `bash -n`/`shellcheck` on the scripts, a launch or dry-run as verification, updating README/`.env.sample` when defaults or measured numbers change, and keeping out-of-the-box behavior working.


## Testing

- YAML frontmatter of all issue templates parses and contains the required keys (`name`, `about`, `title`, `labels`, `assignees`).
- Labels referenced (`bug`, `enhancement`) already exist on the repo.
- Each example/command in the templates was cross-checked against the actual repo files (`start.sh`, `stop.sh`, `check-weights.sh`, `.env.sample`, README "Gotchas"/"KV cache budget").

## Notes

- No existing files modified; only new `.github/` files added (single commit `ad103c8`).
- Contact link points to the repo's X handle since Discussions is disabled on this repo.
