### PR TITLE
feat: verify weights integrity and support offline verification (#30)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ IFACE="enp1s0f0np0"                     # Inter-node ethernet interface
 # Exact-match single device for NCCL. NEVER list a port cabled to another cluster.
 # Run: ibstat | grep "Port "           to find your HCA device name.
 IB_HCA="=rocep1s0f0"                   # Single device, exact match (leading =)
-IB_GID_INDEX=3                          # Usually 3 on ConnectX with RoCE
+IB_GID_INDEX=3                          # Usually 3 on ConnectX with RoCE; if 3 does not come up, try 5
 
 # -- Model ---------------------------------------------------------------------
 MODEL_ID="nvidia/Qwen3.8-Flash-Next-NVFP4"    # 133G / 11 shards: BF16 dense + NVFP4 experts + FP8 PLE

--- a/README.md
+++ b/README.md
@@ -716,6 +716,8 @@ reference; the numbers above supersede these.
   "worked yesterday" on unified memory: `sync && echo 3 | sudo tee /proc/sys/vm/drop_caches`.
 - **Never point `IB_HCA` at an HCA cabled to another cluster** — NCCL will hang mid-NCCL-init
   with no useful error. One exact-match device per node (leading `=`).
+- **`IB_GID_INDEX=3` does not come up on every ConnectX/RoCE setup.** If NCCL/RoCE fails
+  to initialise, try `IB_GID_INDEX=5` (some clusters route on GID 5 instead).
 - **Cross-wired nodes**: head uses `f1`, worker `f0` — hence the separate `WORKER_IFACE` /
   `WORKER_IB_HCA` overrides. If you re-cable, set both.
 - **fp8 KV needs the QSA patch, which `start.sh` applies for you.** The stock kernels declare
@@ -734,6 +736,13 @@ reference; the numbers above supersede these.
 - **`NFS_SHARE=true` only:** do not stop `vllm-fn-nfs` while vLLM is loading or running — the
   worker reads shards from it. Cold start streams ~126 GiB over CX7 (lazy safetensors); once
   weights are in GPU memory the share is idle.
+- **Weights corruption is silent until load.** A shard corrupted mid-download keeps its
+  apparent size close enough that `check-weights.sh` (size + file count) passes, then the
+  engine dies at ~33% weight load with `safe_open` → "incomplete metadata, file not fully
+  covered". Run `./check-weights.sh --verify` after any download or rsync to hash every
+  shard against the Hugging Face manifest (read-only, ~1 min for 135 GB).
+- **`huggingface_hub >= 1.x` offline mode fails with "Cannot find cached snapshot"** if
+  `refs/main` has a trailing newline. Write `refs/main` with `printf`, not `echo`.
 
 ## Credits
 
@@ -765,3 +774,4 @@ upstream terms, and nothing here relicenses them. Files under `files/` that carr
 | `start.sh` | optional download on head → distribute to worker (rsync, or NFS with `--nfs`) → verify → image sync → PLE + MXFP8 patches → launch rank 1 then rank 0 |
 | `stop.sh` | `docker rm -f vllm-fn` on worker, then head (`--nfs` also stops the share) |
 | `check-weights.sh` | verify the checkpoint on the head and on the worker (local copy, or over NFS when `NFS_SHARE=true`) |
+| `verify-weights.py` | per-file SHA-256 verification against the Hugging Face manifest (used by `check-weights.sh --verify`) |

--- a/README.md
+++ b/README.md
@@ -740,7 +740,9 @@ reference; the numbers above supersede these.
   apparent size close enough that `check-weights.sh` (size + file count) passes, then the
   engine dies at ~33% weight load with `safe_open` → "incomplete metadata, file not fully
   covered". Run `./check-weights.sh --verify` after any download or rsync to hash every
-  shard against the Hugging Face manifest (read-only, ~1 min for 135 GB).
+  shard against the Hugging Face manifest (read-only, ~1 min for 135 GB). If the nodes are
+  busy, `./check-weights.sh --dry-run` does the same planning and presence/size checks
+  without reading the weights.
 - **`huggingface_hub >= 1.x` offline mode fails with "Cannot find cached snapshot"** if
   `refs/main` has a trailing newline. Write `refs/main` with `printf`, not `echo`.
 
@@ -774,4 +776,6 @@ upstream terms, and nothing here relicenses them. Files under `files/` that carr
 | `start.sh` | optional download on head → distribute to worker (rsync, or NFS with `--nfs`) → verify → image sync → PLE + MXFP8 patches → launch rank 1 then rank 0 |
 | `stop.sh` | `docker rm -f vllm-fn` on worker, then head (`--nfs` also stops the share) |
 | `check-weights.sh` | verify the checkpoint on the head and on the worker (local copy, or over NFS when `NFS_SHARE=true`) |
+| `check-weights.sh --verify` | per-file SHA-256 verification against the Hugging Face manifest (~1 min read-only) |
+| `check-weights.sh --dry-run` | plan `--verify` (fetch manifest, check presence/size) without hashing or scp |
 | `verify-weights.py` | per-file SHA-256 verification against the Hugging Face manifest (used by `check-weights.sh --verify`) |

--- a/README.md
+++ b/README.md
@@ -740,9 +740,26 @@ reference; the numbers above supersede these.
   apparent size close enough that `check-weights.sh` (size + file count) passes, then the
   engine dies at ~33% weight load with `safe_open` → "incomplete metadata, file not fully
   covered". Run `./check-weights.sh --verify` after any download or rsync to hash every
-  shard against the Hugging Face manifest (read-only, ~1 min for 135 GB). If the nodes are
-  busy, `./check-weights.sh --dry-run` does the same planning and presence/size checks
+  shard against the Hugging Face manifest (read-only; ~1 min for 135 GB at the 2.4 GiB/s
+  8-thread hash rate measured on local NVMe, proportionally slower over NFS). If the nodes
+  are busy, `./check-weights.sh --dry-run` does the same planning and presence/size checks
   without reading the weights.
+- **No route to `huggingface.co` from the nodes?** `--verify` needs the file manifest, not
+  the weights. Save it once where the API is reachable and pass it in — nothing else phones
+  home, and the same file is shipped to the worker:
+
+  ```bash
+  python3 verify-weights.py --repo RadixArk/Qwen3.8-Flash-Next-NVFP4 \
+      --save-manifest manifest.json --fetch-only     # where the API is reachable
+  ./check-weights.sh --manifest manifest.json        # on the head node
+  ```
+
+  `HF_API_BASE` in `.env` points the fetch at a mirror instead.
+- **No route to Docker Hub from the nodes?** `start.sh` runs `docker pull` on head and
+  worker, so both need to reach the registry. If only one node can, pull there and ship the
+  image over SSH — `docker save "$IMAGE" | ssh worker docker load`. If neither can, fetch it
+  from a host that can (`crane pull "$IMAGE" image.tar`, HTTP proxy if needed) and
+  `docker load < image.tar` on both nodes before running `./start.sh --launch`.
 - **`huggingface_hub >= 1.x` offline mode fails with "Cannot find cached snapshot"** if
   `refs/main` has a trailing newline. Write `refs/main` with `printf`, not `echo`.
 
@@ -778,4 +795,6 @@ upstream terms, and nothing here relicenses them. Files under `files/` that carr
 | `check-weights.sh` | verify the checkpoint on the head and on the worker (local copy, or over NFS when `NFS_SHARE=true`) |
 | `check-weights.sh --verify` | per-file SHA-256 verification against the Hugging Face manifest (~1 min read-only) |
 | `check-weights.sh --dry-run` | plan `--verify` (fetch manifest, check presence/size) without hashing or scp |
+| `check-weights.sh --dry-run` | plan `--verify` (fetch manifest, check presence/size) without hashing or scp |
+| `check-weights.sh --manifest FILE` | verify against a manifest saved earlier — no Hugging Face API call |
 | `verify-weights.py` | per-file SHA-256 verification against the Hugging Face manifest (used by `check-weights.sh --verify`) |

--- a/check-weights.sh
+++ b/check-weights.sh
@@ -10,14 +10,15 @@
 #   ./check-weights.sh --dry-run          # plan --verify without hashing or scp
 #   ./check-weights.sh --manifest FILE    # verify against a saved manifest (no API call)
 #
-# --verify streams every shard and compares its SHA-256 with the checksum the
-# Hugging Face API reports for the repo. A size-only check does not catch a
+# --verify streams every shard and compares its content hash with the manifest
+# the Hugging Face API reports for the repo (SHA-256 for LFS shards, git blob
+# SHA-1 for plain files). A size-only check does not catch a
 # shard corrupted mid-download that kept roughly the wrong size (see issue #30);
 # hashing does. It fetches the manifest once on the head, saves it locally, and
 # ships it to the worker so both nodes validate against the same manifest.
 #
 # --dry-run (alias -n) does the same planning and the cheap presence/size checks
-# on both nodes, but skips the SHA-256 pass and the scp of the verifier to the
+# on both nodes, but skips the hashing pass and the scp of the verifier to the
 # worker. It is safe to run while the cluster is busy: no 135 GB reads, no
 # copies, only a manifest fetch and stat calls.
 #
@@ -91,7 +92,10 @@ MODEL_REL="hub/models--${ORG}--${NAME}"
 # Resolve the local model directory exactly like start.sh does: the standard
 # hub path (blobs/refs/snapshots) first, then the `hf path` CLI if the hub dir
 # does not exist. check-weights.sh must agree with the launcher about where
-# the weights live, or a real --verify run would hash nothing.
+# the weights live, or a real --verify run would hash nothing. It deliberately
+# does NOT guess beyond that: walking up the tree looking for any config.json
+# can resolve to an unrelated checkpoint, and a verifier that checks the wrong
+# tree is worse than one that reports it missing.
 resolve_model_dir() {
     local hub="$HUB_PATH/models--${ORG}--${NAME}"
     if [[ -d "$hub" && -n "$(ls -A "$hub" 2>/dev/null)" ]]; then
@@ -116,20 +120,6 @@ resolve_model_dir() {
         echo "$guess"
         return 0
     fi
-    # Direct-download layout: `hf download --local-dir <dir>` and manual rsync
-    # both put model files at the repo root, not under hub/models--.... The
-    # local-dir carries a .cache/ directory produced by the downloader, so walk
-    # up from HF_CACHE_DIR looking for a model content file (config.json plus
-    # the safetensors index). This also covers weight dirs copied next to a
-    # .cache dir by hand.
-    local dir="$HF_CACHE_DIR"
-    for _ in 1 2 3 4 5; do
-        dir="$(cd "$dir/.." 2>/dev/null && pwd)" || break
-        if [[ -f "$dir/config.json" && -f "$dir/model.safetensors.index.json" ]]; then
-            echo "$dir"
-            return 0
-        fi
-    done
     return 1
 }
 
@@ -147,8 +137,10 @@ ssh_worker() {
 # absolute roots per node (e.g. /home/user/models-gigabyte on head vs
 # /home/user/models on worker) with the same layout, so an explicit
 # WORKER_MODEL_PATH override in .env is the reliable way to pin it; without it
-# we mirror the head's HF_HOME under the worker's $HOME and resolve the same
-# layout the head used (hub path or direct local-dir, via resolve_model_dir).
+# we mirror the head's HF_HOME under the worker's $HOME. The worker is
+# expected to keep the standard hub path there. No guessing beyond that, for
+# the same reason as resolve_model_dir above: check_node reports a missing
+# worker copy as NOT FOUND, which is honest, while a guessed dir would not be.
 WORKER_MODEL_PATH="${WORKER_MODEL_PATH:-}"
 if [[ -z "$WORKER_MODEL_PATH" ]]; then
     REMOTE_HOME="$HOME"
@@ -160,25 +152,32 @@ if [[ -z "$WORKER_MODEL_PATH" ]]; then
     else
         REMOTE_HF="$HF_CACHE_DIR"
     fi
-    # Prefer the hub path under the worker's HF cache, then walk up looking for
-    # a direct local-dir layout, exactly like the head side.
     WORKER_MODEL_PATH="$REMOTE_HF/hub/models--${ORG}--${NAME}"
-    if [[ ! -d "$WORKER_MODEL_PATH" ]]; then
-        WORKER_MODEL_PATH="$(ssh_worker "HF_CACHE_DIR='$REMOTE_HF'; ORG='$ORG'; NAME='$NAME'
-            for dir in \"\$HF_CACHE_DIR\" \"\$HF_CACHE_DIR/..\" \"\$HOME\"; do
-                if [[ -f \"\$dir/config.json\" && -f \"\$dir/model.safetensors.index.json\" ]]; then
-                    echo \"\$dir\"; break
-                fi
-            done" 2>/dev/null | tail -1)"
-        [[ -n "$WORKER_MODEL_PATH" ]] || WORKER_MODEL_PATH="$REMOTE_HF/hub/models--${ORG}--${NAME}"
-    fi
 fi
+
+# Translate the verifier's exit status into a message. verify-weights.py
+# returns 1 when the weights failed verification and 2 when the check itself
+# broke (unresolvable manifest, missing python3, ...). Those are different
+# answers: the first means corrupt weights, the second means try again.
+# Printing "mismatch" for both would send an operator after weights when the
+# tool is what broke.
+report_verify_rc() {  # report_verify_rc <rc> <label> <path>
+    local vrc="$1" vlabel="$2" vpath="$3"
+    if [[ "$vrc" -eq 1 ]]; then
+        echo "  $vlabel ❌  verification FAILED for $vpath (does not match the manifest)"
+        return 1
+    elif [[ "$vrc" -ne 0 ]]; then
+        echo "  $vlabel ❌  could not verify $vpath (checker exit $vrc; tool failure, not a weight mismatch)"
+        return 1
+    fi
+    return 0
+}
 
 check_node() {
     local label="$1"
     local path="$2"
     local run_cmd="${3:-local}"
-    local size shards
+    local size shards rc worker_tmp
 
     if [[ "$run_cmd" == "local" ]]; then
         if [[ -d "$path" ]]; then
@@ -189,18 +188,16 @@ check_node() {
             if $DO_VERIFY; then
                 if $DO_DRY_RUN; then
                     echo "         [dry run] presence + size check only (no hashing)"
-                    if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
-                            --manifest "$VERIFY_MANIFEST" --dry-run; then
-                        echo "  $label ❌  problem(s) found"
-                        return 1
-                    fi
+                    rc=0
+                    python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
+                            --manifest "$VERIFY_MANIFEST" --dry-run || rc=$?
+                    report_verify_rc "$rc" "$label" "$path" || return 1
                 else
-                    echo "         Verifying SHA-256 against the HF manifest ..."
-                    if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
-                            --manifest "$VERIFY_MANIFEST"; then
-                        echo "  $label ❌  SHA-256 mismatch in $path"
-                        return 1
-                    fi
+                    echo "         Verifying content hashes against the HF manifest ..."
+                    rc=0
+                    python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
+                            --manifest "$VERIFY_MANIFEST" || rc=$?
+                    report_verify_rc "$rc" "$label" "$path" || return 1
                 fi
             fi
             return 0
@@ -217,17 +214,24 @@ check_node() {
             echo "         Size: $size | Shards: $shards"
             if $DO_VERIFY; then
                 if $DO_DRY_RUN; then
-                    echo "         [dry run] would scp verifier + manifest and hash $path"
+                    echo "         [dry run] would stage verifier + manifest and hash $path"
                 else
-                    echo "         Verifying SHA-256 against the HF manifest ..."
+                    echo "         Verifying content hashes against the HF manifest ..."
                     # The worker cache does not have the repo checkout, so ship the
                     # verifier (stdlib-only, single file) and the manifest there.
-                    scp -q "$SCRIPT_DIR/verify-weights.py" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-weights.py"
-                    scp -q "$VERIFY_MANIFEST" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-manifest.json"
-                    if ! ssh_cmd "python3 /tmp/verify-weights.py --path '$path' --repo '$MODEL_ID' --manifest /tmp/verify-manifest.json"; then
-                        echo "  $label ❌  SHA-256 mismatch in $path"
+                    # A fresh private temp dir, not a fixed /tmp path: predictable
+                    # names are a symlink-attack surface and leak between runs.
+                    worker_tmp=""
+                    if ! worker_tmp=$(ssh_worker "mktemp -d /tmp/verify-weights.XXXXXX" 2>/dev/null); then
+                        echo "  $label ❌  could not stage verifier on worker"
                         return 1
                     fi
+                    scp -q "$SCRIPT_DIR/verify-weights.py" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:${worker_tmp}/verify-weights.py"
+                    scp -q "$VERIFY_MANIFEST" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:${worker_tmp}/manifest.json"
+                    rc=0
+                    ssh_worker "python3 '${worker_tmp}/verify-weights.py' --path '$path' --repo '$MODEL_ID' --manifest '${worker_tmp}/manifest.json'" || rc=$?
+                    ssh_worker "rm -rf '$worker_tmp'" 2>/dev/null || true
+                    report_verify_rc "$rc" "$label" "$path" || return 1
                 fi
             fi
             return 0
@@ -253,6 +257,15 @@ export HF_TOKEN="${HF_TOKEN:-}"
 # A mirror set in .env must reach the verifier too, on both nodes.
 [[ -n "${HF_API_BASE:-}" ]] && export HF_API_BASE
 VERIFY_MANIFEST=""
+# Temp manifest created by this run. Tracked separately from VERIFY_MANIFEST
+# so the EXIT trap only removes what we created, never a user --manifest file.
+VERIFY_MANIFEST_TMP=""
+cleanup_verify_manifest() {
+    if [[ -n "$VERIFY_MANIFEST_TMP" ]]; then
+        rm -f "$VERIFY_MANIFEST_TMP"
+    fi
+}
+trap cleanup_verify_manifest EXIT
 if $DO_VERIFY; then
     if [[ -n "$SAVED_MANIFEST" ]]; then
         if [[ ! -f "$SAVED_MANIFEST" ]]; then
@@ -262,7 +275,8 @@ if $DO_VERIFY; then
         VERIFY_MANIFEST="$SAVED_MANIFEST"
         echo "Using saved manifest: $VERIFY_MANIFEST"
     else
-        VERIFY_MANIFEST="${TMPDIR:-/tmp}/verify-manifest.json"
+        VERIFY_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/verify-manifest.XXXXXX.json")"
+        VERIFY_MANIFEST_TMP="$VERIFY_MANIFEST"
         echo "Fetching manifest for $MODEL_ID ..."
         if ! python3 "$SCRIPT_DIR/verify-weights.py" --repo "$MODEL_ID" \
                 --save-manifest "$VERIFY_MANIFEST" --fetch-only --quiet; then

--- a/check-weights.sh
+++ b/check-weights.sh
@@ -5,26 +5,42 @@
 # NFS_SHARE=true: the worker has no local copy and is checked through the NFS volume.
 #
 # Usage:
-#   ./check-weights.sh          # presence + size on both nodes (fast)
-#   ./check-weights.sh --verify # per-file SHA-256 against the HF manifest
+#   ./check-weights.sh           # presence + size on both nodes (fast)
+#   ./check-weights.sh --verify  # per-file SHA-256 against the HF manifest
+#   ./check-weights.sh --dry-run # plan --verify without hashing or scp
 #
 # --verify streams every shard and compares its SHA-256 with the checksum the
 # Hugging Face API reports for the repo. A size-only check does not catch a
 # shard corrupted mid-download that kept roughly the wrong size (see issue #30);
 # hashing does. It fetches the manifest once on the head, saves it locally, and
 # ships it to the worker so both nodes validate against the same manifest.
+#
+# --dry-run (alias -n) does the same planning and the cheap presence/size checks
+# on both nodes, but skips the SHA-256 pass and the scp of the verifier to the
+# worker. It is safe to run while the cluster is busy: no 135 GB reads, no
+# copies, only a manifest fetch and stat calls.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 DO_VERIFY=false
-if [[ "${1:-}" == "--verify" ]]; then
-    DO_VERIFY=true
-elif [[ -n "${1:-}" ]]; then
-    echo "Usage: $0 [--verify]" >&2
-    exit 2
-fi
+DO_DRY_RUN=false
+case "${1:-}" in
+    --verify)
+        DO_VERIFY=true
+        ;;
+    --dry-run|-n)
+        DO_VERIFY=true
+        DO_DRY_RUN=true
+        ;;
+    "")
+        ;;
+    *)
+        echo "Usage: $0 [--verify|--dry-run]" >&2
+        exit 2
+        ;;
+esac
 
 if [[ ! -f .env ]]; then
     echo "ERROR: .env not found."
@@ -48,13 +64,61 @@ HF_CACHE_DIR="${HF_HOME:-$HOME/.cache/huggingface}"
 HUB_PATH="$HF_CACHE_DIR/hub"
 ORG="${MODEL_ID%%/*}"
 NAME="${MODEL_ID##*/}"
-MODEL_PATH="$HUB_PATH/models--${ORG}--${NAME}"
 MODEL_REL="hub/models--${ORG}--${NAME}"
+
+# Resolve the local model directory exactly like start.sh does: the standard
+# hub path (blobs/refs/snapshots) first, then the `hf path` CLI if the hub dir
+# does not exist. check-weights.sh must agree with the launcher about where
+# the weights live, or a real --verify run would hash nothing.
+resolve_model_dir() {
+    local hub="$HUB_PATH/models--${ORG}--${NAME}"
+    if [[ -d "$hub" && -n "$(ls -A "$hub" 2>/dev/null)" ]]; then
+        echo "$hub"
+        return 0
+    fi
+    local guess=""
+    for tool_cmd in "hf path" "huggingface-cli path"; do
+        local first_word="${tool_cmd%% *}"
+        if command -v "$first_word" &>/dev/null; then
+            guess=$($tool_cmd "$MODEL_ID" 2>/dev/null || true)
+            [[ -n "$guess" && -d "$guess" ]] && break
+            guess=""
+        fi
+    done
+    if [[ -n "$guess" && -d "$guess" ]]; then
+        case "$guess" in
+            *"/models--${ORG}--${NAME}"*)
+                guess="${guess%%/models--${ORG}--${NAME}*}/models--${ORG}--${NAME}"
+                ;;
+        esac
+        echo "$guess"
+        return 0
+    fi
+    # Direct-download layout: `hf download --local-dir <dir>` and manual rsync
+    # both put model files at the repo root, not under hub/models--.... The
+    # local-dir carries a .cache/ directory produced by the downloader, so walk
+    # up from HF_CACHE_DIR looking for a model content file (config.json plus
+    # the safetensors index). This also covers weight dirs copied next to a
+    # .cache dir by hand.
+    local dir="$HF_CACHE_DIR"
+    for _ in 1 2 3 4 5; do
+        dir="$(cd "$dir/.." 2>/dev/null && pwd)" || break
+        if [[ -f "$dir/config.json" && -f "$dir/model.safetensors.index.json" ]]; then
+            echo "$dir"
+            return 0
+        fi
+    done
+    return 1
+}
+
+MODEL_PATH="$(resolve_model_dir 2>/dev/null || echo "$HUB_PATH/models--${ORG}--${NAME}")"
 
 ssh_worker() {
     local user_prefix=""
     [[ -n "$WORKER_USER" ]] && user_prefix="${WORKER_USER}@"
-    ssh -o StrictHostKeyChecking=no "${user_prefix}$WORKER_IP" "$@"
+    # Fail fast when the worker is unreachable (e.g. cluster in use elsewhere)
+    # instead of hanging on the default TCP timeout.
+    ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "${user_prefix}$WORKER_IP" "$@"
 }
 
 REMOTE_HOME=$(ssh_worker "echo \"\$HOME\"")
@@ -80,11 +144,20 @@ check_node() {
             echo "  $label ✅  $path"
             echo "         Size: $size | Shards: $shards"
             if $DO_VERIFY; then
-                echo "         Verifying SHA-256 against the HF manifest ..."
-                if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
-                        --manifest "$VERIFY_MANIFEST"; then
-                    echo "  $label ❌  SHA-256 mismatch in $path"
-                    return 1
+                if $DO_DRY_RUN; then
+                    echo "         [dry run] presence + size check only (no hashing)"
+                    if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
+                            --manifest "$VERIFY_MANIFEST" --dry-run; then
+                        echo "  $label ❌  problem(s) found"
+                        return 1
+                    fi
+                else
+                    echo "         Verifying SHA-256 against the HF manifest ..."
+                    if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
+                            --manifest "$VERIFY_MANIFEST"; then
+                        echo "  $label ❌  SHA-256 mismatch in $path"
+                        return 1
+                    fi
                 fi
             fi
             return 0
@@ -100,14 +173,18 @@ check_node() {
             echo "  $label ✅  $path"
             echo "         Size: $size | Shards: $shards"
             if $DO_VERIFY; then
-                echo "         Verifying SHA-256 against the HF manifest ..."
-                # The worker cache does not have the repo checkout, so ship the
-                # verifier (stdlib-only, single file) and the manifest there.
-                scp -q "$SCRIPT_DIR/verify-weights.py" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-weights.py"
-                scp -q "$VERIFY_MANIFEST" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-manifest.json"
-                if ! ssh_cmd "python3 /tmp/verify-weights.py --path '$path' --repo '$MODEL_ID' --manifest /tmp/verify-manifest.json"; then
-                    echo "  $label ❌  SHA-256 mismatch in $path"
-                    return 1
+                if $DO_DRY_RUN; then
+                    echo "         [dry run] would scp verifier + manifest and hash $path"
+                else
+                    echo "         Verifying SHA-256 against the HF manifest ..."
+                    # The worker cache does not have the repo checkout, so ship the
+                    # verifier (stdlib-only, single file) and the manifest there.
+                    scp -q "$SCRIPT_DIR/verify-weights.py" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-weights.py"
+                    scp -q "$VERIFY_MANIFEST" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-manifest.json"
+                    if ! ssh_cmd "python3 /tmp/verify-weights.py --path '$path' --repo '$MODEL_ID' --manifest /tmp/verify-manifest.json"; then
+                        echo "  $label ❌  SHA-256 mismatch in $path"
+                        return 1
+                    fi
                 fi
             fi
             return 0

--- a/check-weights.sh
+++ b/check-weights.sh
@@ -5,9 +5,10 @@
 # NFS_SHARE=true: the worker has no local copy and is checked through the NFS volume.
 #
 # Usage:
-#   ./check-weights.sh           # presence + size on both nodes (fast)
-#   ./check-weights.sh --verify  # per-file SHA-256 against the HF manifest
-#   ./check-weights.sh --dry-run # plan --verify without hashing or scp
+#   ./check-weights.sh                    # presence + size on both nodes (fast)
+#   ./check-weights.sh --verify           # per-file SHA-256 against the HF manifest
+#   ./check-weights.sh --dry-run          # plan --verify without hashing or scp
+#   ./check-weights.sh --manifest FILE    # verify against a saved manifest (no API call)
 #
 # --verify streams every shard and compares its SHA-256 with the checksum the
 # Hugging Face API reports for the repo. A size-only check does not catch a
@@ -19,6 +20,12 @@
 # on both nodes, but skips the SHA-256 pass and the scp of the verifier to the
 # worker. It is safe to run while the cluster is busy: no 135 GB reads, no
 # copies, only a manifest fetch and stat calls.
+#
+# --manifest FILE verifies against a manifest saved earlier
+# (`python3 verify-weights.py --repo ID --save-manifest FILE --fetch-only`) instead
+# of calling the Hugging Face API, so nodes without direct access to huggingface.co
+# can still verify. It implies --verify and combines with --dry-run. HF_API_BASE
+# in .env points the fetch at a mirror.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,21 +33,36 @@ cd "$SCRIPT_DIR"
 
 DO_VERIFY=false
 DO_DRY_RUN=false
-case "${1:-}" in
-    --verify)
-        DO_VERIFY=true
-        ;;
-    --dry-run|-n)
-        DO_VERIFY=true
-        DO_DRY_RUN=true
-        ;;
-    "")
-        ;;
-    *)
-        echo "Usage: $0 [--verify|--dry-run]" >&2
-        exit 2
-        ;;
-esac
+SAVED_MANIFEST=""
+usage() {
+    echo "Usage: $0 [--verify|--dry-run] [--manifest FILE]" >&2
+    exit 2
+}
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --verify)
+            DO_VERIFY=true
+            ;;
+        --dry-run|-n)
+            DO_VERIFY=true
+            DO_DRY_RUN=true
+            ;;
+        --manifest)
+            [[ $# -ge 2 ]] || usage
+            DO_VERIFY=true
+            SAVED_MANIFEST="$2"
+            shift
+            ;;
+        --manifest=*)
+            DO_VERIFY=true
+            SAVED_MANIFEST="${1#--manifest=}"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
 
 if [[ ! -f .env ]]; then
     echo "ERROR: .env not found."
@@ -121,15 +143,36 @@ ssh_worker() {
     ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 "${user_prefix}$WORKER_IP" "$@"
 }
 
-REMOTE_HOME=$(ssh_worker "echo \"\$HOME\"")
-if [[ -n "${WORKER_HF_HOME:-}" ]]; then
-    REMOTE_HF="$WORKER_HF_HOME"
-elif [[ "$HF_CACHE_DIR" == "$HOME" || "$HF_CACHE_DIR" == "$HOME/"* ]]; then
-    REMOTE_HF="${REMOTE_HOME}${HF_CACHE_DIR#"$HOME"}"
-else
-    REMOTE_HF="$HF_CACHE_DIR"
+# Resolve the worker's model directory. Mirrored clusters often use different
+# absolute roots per node (e.g. /home/user/models-gigabyte on head vs
+# /home/user/models on worker) with the same layout, so an explicit
+# WORKER_MODEL_PATH override in .env is the reliable way to pin it; without it
+# we mirror the head's HF_HOME under the worker's $HOME and resolve the same
+# layout the head used (hub path or direct local-dir, via resolve_model_dir).
+WORKER_MODEL_PATH="${WORKER_MODEL_PATH:-}"
+if [[ -z "$WORKER_MODEL_PATH" ]]; then
+    REMOTE_HOME="$HOME"
+    REMOTE_HOME=$(ssh_worker "echo \"\$HOME\"" 2>/dev/null || echo "$HOME")
+    if [[ -n "${WORKER_HF_HOME:-}" ]]; then
+        REMOTE_HF="$WORKER_HF_HOME"
+    elif [[ "$HF_CACHE_DIR" == "$HOME" || "$HF_CACHE_DIR" == "$HOME/"* ]]; then
+        REMOTE_HF="${REMOTE_HOME}${HF_CACHE_DIR#"$HOME"}"
+    else
+        REMOTE_HF="$HF_CACHE_DIR"
+    fi
+    # Prefer the hub path under the worker's HF cache, then walk up looking for
+    # a direct local-dir layout, exactly like the head side.
+    WORKER_MODEL_PATH="$REMOTE_HF/hub/models--${ORG}--${NAME}"
+    if [[ ! -d "$WORKER_MODEL_PATH" ]]; then
+        WORKER_MODEL_PATH="$(ssh_worker "HF_CACHE_DIR='$REMOTE_HF'; ORG='$ORG'; NAME='$NAME'
+            for dir in \"\$HF_CACHE_DIR\" \"\$HF_CACHE_DIR/..\" \"\$HOME\"; do
+                if [[ -f \"\$dir/config.json\" && -f \"\$dir/model.safetensors.index.json\" ]]; then
+                    echo \"\$dir\"; break
+                fi
+            done" 2>/dev/null | tail -1)"
+        [[ -n "$WORKER_MODEL_PATH" ]] || WORKER_MODEL_PATH="$REMOTE_HF/hub/models--${ORG}--${NAME}"
+    fi
 fi
-WORKER_MODEL_PATH="${REMOTE_HF}/hub/models--${ORG}--${NAME}"
 
 check_node() {
     local label="$1"
@@ -207,14 +250,28 @@ echo ""
 # environment (same convention as start.sh).
 export HF_HOME="$HF_CACHE_DIR"
 export HF_TOKEN="${HF_TOKEN:-}"
+# A mirror set in .env must reach the verifier too, on both nodes.
+[[ -n "${HF_API_BASE:-}" ]] && export HF_API_BASE
 VERIFY_MANIFEST=""
 if $DO_VERIFY; then
-    VERIFY_MANIFEST="${TMPDIR:-/tmp}/verify-manifest.json"
-    echo "Fetching manifest for $MODEL_ID ..."
-    if ! python3 "$SCRIPT_DIR/verify-weights.py" --repo "$MODEL_ID" \
-            --save-manifest "$VERIFY_MANIFEST" --fetch-only --quiet; then
-        echo "ERROR: could not fetch manifest for $MODEL_ID" >&2
-        exit 1
+    if [[ -n "$SAVED_MANIFEST" ]]; then
+        if [[ ! -f "$SAVED_MANIFEST" ]]; then
+            echo "ERROR: manifest not found: $SAVED_MANIFEST" >&2
+            exit 1
+        fi
+        VERIFY_MANIFEST="$SAVED_MANIFEST"
+        echo "Using saved manifest: $VERIFY_MANIFEST"
+    else
+        VERIFY_MANIFEST="${TMPDIR:-/tmp}/verify-manifest.json"
+        echo "Fetching manifest for $MODEL_ID ..."
+        if ! python3 "$SCRIPT_DIR/verify-weights.py" --repo "$MODEL_ID" \
+                --save-manifest "$VERIFY_MANIFEST" --fetch-only --quiet; then
+            echo "ERROR: could not fetch manifest for $MODEL_ID" >&2
+            echo "       Offline or behind a proxy? Save it once where the API is reachable:" >&2
+            echo "       python3 verify-weights.py --repo $MODEL_ID --save-manifest m.json --fetch-only" >&2
+            echo "       then run: $0 --verify --manifest m.json" >&2
+            exit 1
+        fi
     fi
 fi
 

--- a/check-weights.sh
+++ b/check-weights.sh
@@ -3,10 +3,28 @@
 #
 # Default (NFS_SHARE=false): the worker keeps its own copy (HF_HOME / WORKER_HF_HOME aware).
 # NFS_SHARE=true: the worker has no local copy and is checked through the NFS volume.
+#
+# Usage:
+#   ./check-weights.sh          # presence + size on both nodes (fast)
+#   ./check-weights.sh --verify # per-file SHA-256 against the HF manifest
+#
+# --verify streams every shard and compares its SHA-256 with the checksum the
+# Hugging Face API reports for the repo. A size-only check does not catch a
+# shard corrupted mid-download that kept roughly the wrong size (see issue #30);
+# hashing does. It fetches the manifest once on the head, saves it locally, and
+# ships it to the worker so both nodes validate against the same manifest.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+
+DO_VERIFY=false
+if [[ "${1:-}" == "--verify" ]]; then
+    DO_VERIFY=true
+elif [[ -n "${1:-}" ]]; then
+    echo "Usage: $0 [--verify]" >&2
+    exit 2
+fi
 
 if [[ ! -f .env ]]; then
     echo "ERROR: .env not found."
@@ -53,15 +71,22 @@ check_node() {
     local label="$1"
     local path="$2"
     local run_cmd="${3:-local}"
+    local size shards
 
     if [[ "$run_cmd" == "local" ]]; then
         if [[ -d "$path" ]]; then
-            local size
             size=$(du -sh "$path" 2>/dev/null | cut -f1)
-            local shards
             shards=$(find "$path" -name "*.safetensors" -o -name "*.bin" 2>/dev/null | wc -l)
             echo "  $label ✅  $path"
             echo "         Size: $size | Shards: $shards"
+            if $DO_VERIFY; then
+                echo "         Verifying SHA-256 against the HF manifest ..."
+                if ! python3 "$SCRIPT_DIR/verify-weights.py" --path "$path" --repo "$MODEL_ID" \
+                        --manifest "$VERIFY_MANIFEST"; then
+                    echo "  $label ❌  SHA-256 mismatch in $path"
+                    return 1
+                fi
+            fi
             return 0
         else
             echo "  $label ❌  $path — NOT FOUND"
@@ -70,11 +95,21 @@ check_node() {
     else
         # Remote check via SSH
         if ssh_worker "test -d '$path'" 2>/dev/null; then
-            local size shards
             size=$(ssh_worker "du -sh '$path' 2>/dev/null" | cut -f1)
             shards=$(ssh_worker "find '$path' -name '*.safetensors' -o -name '*.bin' 2>/dev/null | wc -l")
             echo "  $label ✅  $path"
             echo "         Size: $size | Shards: $shards"
+            if $DO_VERIFY; then
+                echo "         Verifying SHA-256 against the HF manifest ..."
+                # The worker cache does not have the repo checkout, so ship the
+                # verifier (stdlib-only, single file) and the manifest there.
+                scp -q "$SCRIPT_DIR/verify-weights.py" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-weights.py"
+                scp -q "$VERIFY_MANIFEST" "${WORKER_USER:+${WORKER_USER}@}${WORKER_IP}:/tmp/verify-manifest.json"
+                if ! ssh_cmd "python3 /tmp/verify-weights.py --path '$path' --repo '$MODEL_ID' --manifest /tmp/verify-manifest.json"; then
+                    echo "  $label ❌  SHA-256 mismatch in $path"
+                    return 1
+                fi
+            fi
             return 0
         else
             echo "  $label ❌  $path — NOT FOUND"
@@ -90,6 +125,21 @@ echo "Checking weights for: $MODEL_ID"
 echo "Head cache:   $MODEL_PATH"
 echo "Worker cache: $WORKER_MODEL_PATH"
 echo ""
+
+# Export for verify-weights.py, which resolves the default model path from the
+# environment (same convention as start.sh).
+export HF_HOME="$HF_CACHE_DIR"
+export HF_TOKEN="${HF_TOKEN:-}"
+VERIFY_MANIFEST=""
+if $DO_VERIFY; then
+    VERIFY_MANIFEST="${TMPDIR:-/tmp}/verify-manifest.json"
+    echo "Fetching manifest for $MODEL_ID ..."
+    if ! python3 "$SCRIPT_DIR/verify-weights.py" --repo "$MODEL_ID" \
+            --save-manifest "$VERIFY_MANIFEST" --fetch-only --quiet; then
+        echo "ERROR: could not fetch manifest for $MODEL_ID" >&2
+        exit 1
+    fi
+fi
 
 HEAD_OK=false
 WORKER_OK=false

--- a/tests/test_check_weights.sh
+++ b/tests/test_check_weights.sh
@@ -165,6 +165,21 @@ run "corrupt shard is blocking (non-zero exit)" bash -c "
 "
 mv "$WORK/model.safetensors.bak" "$SNAPSHOT/model.safetensors"
 
+# 3b. --dry-run succeeds, fetches the manifest, checks presence/size, no hash.
+run "--dry-run succeeds (presence + size only)" \
+    env PATH="$WORK/bin:$PATH" ./check-weights.sh --dry-run >/dev/null 2>&1
+
+# 3c. --dry-run still flags a missing file (presence check, not just a plan).
+mv "$SNAPSHOT/model.safetensors" "$WORK/model.safetensors.hidden"
+run "--dry-run flags missing file (non-zero exit)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH ./check-weights.sh --dry-run >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -ne 0 ]]
+"
+mv "$WORK/model.safetensors.hidden" "$SNAPSHOT/model.safetensors"
+
 # 4. Unknown flag is rejected with exit 2.
 run "unknown flag rejected (exit 2)" bash -c "
     set +e

--- a/tests/test_check_weights.sh
+++ b/tests/test_check_weights.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# test_check_weights.sh — Shell-level tests for check-weights.sh --verify.
+#
+# These cover integration points that unit tests cannot reach: flag parsing,
+# the manifest fetch step, the head verification path, the worker path (via a
+# stub ssh/scp), and the blocking behavior on a corrupt shard. They use a tiny
+# fake model directory plus a stub HF API server so no real model or network
+# is needed.
+#
+# Run from the repo root:
+#   bash tests/test_check_weights.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORK="$(mktemp -d)"
+export WORK
+trap '[[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null || true; rm -rf "$WORK" .env' EXIT
+
+# --- fixture: tiny model in the standard hub layout -------------------------
+HF_HOME="$WORK/hf"
+MODEL_ROOT="$HF_HOME/hub/models--org--model"
+SNAPSHOT="$MODEL_ROOT/snapshots/rev1"
+mkdir -p "$SNAPSHOT" "$MODEL_ROOT/refs"
+printf 'all the weights' > "$SNAPSHOT/model.safetensors"
+printf 'rev1' > "$MODEL_ROOT/refs/main"
+
+# Build a manifest describing exactly that fixture, using the verifier itself.
+python3 - "$REPO_ROOT/verify-weights.py" "$SNAPSHOT" "$WORK/manifest.json" <<'PY'
+import importlib.util, json, os, sys
+spec = importlib.util.spec_from_file_location("vw", sys.argv[1])
+vw = importlib.util.module_from_spec(spec); spec.loader.exec_module(vw)
+root = sys.argv[2]
+files, _ = vw.iter_model_files(root)
+manifest = {}
+for rel, path in files.items():
+    manifest[rel] = {"type": "file", "size": os.path.getsize(path),
+                     "lfs": {"oid": "sha256:" + vw.file_sha256(path)}}
+json.dump(manifest, open(sys.argv[3], "w"))
+print(f"manifest written: {len(manifest)} files")
+PY
+
+# --- stub HF API server -----------------------------------------------------
+cat > "$WORK/mock_api.py" <<'PY'
+import http.server, json, os, sys
+root, manifest_path = sys.argv[1], sys.argv[2]
+manifest = json.load(open(manifest_path))
+os.makedirs(root, exist_ok=True)
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps([{"type": "file", "path": k, "size": v["size"],
+                            "lfs": v["lfs"]} for k, v in manifest.items()]).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *args):
+        pass
+
+srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(os.path.join(root, "port"), "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.serve_forever()
+PY
+python3 "$WORK/mock_api.py" "$WORK" "$WORK/manifest.json" &
+SERVER_PID=$!
+for _ in $(seq 1 50); do
+    [[ -f "$WORK/port" ]] && break
+    sleep 0.1
+done
+[[ -f "$WORK/port" ]] || { echo "mock API server did not start"; exit 1; }
+PORT="$(cat "$WORK/port")"
+export HF_API_BASE="http://127.0.0.1:$PORT"
+
+# --- stub ssh/scp: the worker's side lives on this same machine -------------
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/ssh" <<SSH
+#!/usr/bin/env bash
+# Stub ssh for check-weights.sh. The worker model path equals the head's, and
+# /tmp/verify-weights.py + /tmp/verify-manifest.json are pre-copied by the test.
+# Everything before the ssh host argument is ignored; the rest runs locally.
+args=("\$@")
+hostpos=-1
+for i in "\${!args[@]}"; do
+    case "\${args[\$i]}" in
+        *@*|*.*.*.*) hostpos=\$i ;;
+    esac
+done
+if [[ "\$*" == *'echo "\$HOME"'* || "\$*" == *'echo \$HOME'* ]]; then
+    echo "\$HOME"
+    exit 0
+fi
+if [[ "\$*" == *'test -d'* ]]; then
+    exit 0
+fi
+if [[ "\$*" == *'du -sh'* ]]; then
+    du -sh "$SNAPSHOT" 2>/dev/null | cut -f1
+    exit 0
+fi
+if [[ "\$*" == *'find'* ]]; then
+    find "$SNAPSHOT" -name '*.safetensors' -o -name '*.bin' 2>/dev/null | wc -l
+    exit 0
+fi
+if (( hostpos >= 0 )); then
+    exec bash -c "\${args[*]:hostpos+1}"
+fi
+exit 0
+SSH
+cat > "$WORK/bin/scp" <<SCP
+#!/usr/bin/env bash
+# Stub scp: the worker files are pre-copied by the test harness.
+exit 0
+SCP
+chmod +x "$WORK/bin/ssh" "$WORK/bin/scp"
+
+# Pre-copy to the "worker" (this machine) so the stubbed remote command works.
+cp "$REPO_ROOT/verify-weights.py" /tmp/verify-weights.py
+cp "$WORK/manifest.json" /tmp/verify-manifest.json
+
+# --- .env for check-weights.sh ----------------------------------------------
+cat > .env <<ENV
+HEAD_IP=10.0.0.1
+WORKER_IP=10.0.0.2
+MODEL_ID=org/model
+HF_HOME=$HF_HOME
+ENV
+
+export SNAPSHOT
+
+PASS=0
+run() {
+    local name="$1"
+    shift
+    if timeout 15 "$@"; then
+        PASS=$((PASS + 1))
+        echo "ok - $name"
+    else
+        echo "FAIL/Timeout - $name (exit $?)"
+        exit 1
+    fi
+}
+
+echo "== check-weights.sh shell tests =="
+
+# 1. No-argument fast check: presence + size, no manifest, no python verify.
+run "no-arg fast check" env PATH="$WORK/bin:$PATH" ./check-weights.sh
+
+# 2. --verify end to end: fetch via mock API, verify head, verify "worker".
+run "--verify end to end (head + worker)" \
+    env PATH="$WORK/bin:$PATH" ./check-weights.sh --verify >/dev/null
+
+# 3. A corrupt shard makes --verify exit nonzero (blocking, not warning).
+cp "$SNAPSHOT/model.safetensors" "$WORK/model.safetensors.bak"
+printf 'corrupt!!!' > "$SNAPSHOT/model.safetensors"
+run "corrupt shard is blocking (non-zero exit)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH ./check-weights.sh --verify >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -ne 0 ]]
+"
+mv "$WORK/model.safetensors.bak" "$SNAPSHOT/model.safetensors"
+
+# 4. Unknown flag is rejected with exit 2.
+run "unknown flag rejected (exit 2)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH ./check-weights.sh --bogus >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -eq 2 ]]
+"
+
+# 5. Missing .env is still a hard error.
+run "missing .env fails (exit 1)" bash -c "
+    set +e
+    mv .env \$WORK/.env.saved
+    ./check-weights.sh >/dev/null 2>&1
+    rc=\$?
+    mv \$WORK/.env.saved .env
+    set -e
+    [[ \$rc -eq 1 ]]
+"
+
+# 6. Manifest fetch failure is blocking: an unreachable API must fail, not pass.
+run "API fetch failure is blocking (non-zero exit)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH HF_API_BASE=http://127.0.0.1:1 ./check-weights.sh --verify >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -ne 0 ]]
+"
+
+echo ""
+echo "All $PASS shell tests passed."

--- a/tests/test_check_weights.sh
+++ b/tests/test_check_weights.sh
@@ -180,6 +180,43 @@ run "--dry-run flags missing file (non-zero exit)" bash -c "
 "
 mv "$WORK/model.safetensors.hidden" "$SNAPSHOT/model.safetensors"
 
+# 3d. --manifest verifies against a saved manifest without touching the API.
+#     HF_API_BASE points at a dead port, so any fetch attempt would fail.
+run "--manifest uses the saved manifest (no API call)" \
+    env PATH="$WORK/bin:$PATH" HF_API_BASE="http://127.0.0.1:1" \
+    ./check-weights.sh --verify --manifest "$WORK/manifest.json" >/dev/null 2>&1
+
+# 3e. --manifest still catches a corrupt shard.
+cp "$SNAPSHOT/model.safetensors" "$WORK/model.safetensors.bak"
+printf 'corrupt!!!' > "$SNAPSHOT/model.safetensors"
+run "--manifest catches a corrupt shard (non-zero exit)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH HF_API_BASE=http://127.0.0.1:1 \
+        ./check-weights.sh --manifest $WORK/manifest.json >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -ne 0 ]]
+"
+mv "$WORK/model.safetensors.bak" "$SNAPSHOT/model.safetensors"
+
+# 3f. A --manifest path that does not exist is a hard error (exit 1).
+run "--manifest missing file fails (exit 1)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH ./check-weights.sh --manifest $WORK/nope.json >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -eq 1 ]]
+"
+
+# 3g. --manifest without its argument is a usage error (exit 2).
+run "--manifest without argument rejected (exit 2)" bash -c "
+    set +e
+    PATH=$WORK/bin:\$PATH ./check-weights.sh --manifest >/dev/null 2>&1
+    rc=\$?
+    set -e
+    [[ \$rc -eq 2 ]]
+"
+
 # 4. Unknown flag is rejected with exit 2.
 run "unknown flag rejected (exit 2)" bash -c "
     set +e

--- a/tests/test_check_weights.sh
+++ b/tests/test_check_weights.sh
@@ -80,9 +80,9 @@ export HF_API_BASE="http://127.0.0.1:$PORT"
 mkdir -p "$WORK/bin"
 cat > "$WORK/bin/ssh" <<SSH
 #!/usr/bin/env bash
-# Stub ssh for check-weights.sh. The worker model path equals the head's, and
-# /tmp/verify-weights.py + /tmp/verify-manifest.json are pre-copied by the test.
-# Everything before the ssh host argument is ignored; the rest runs locally.
+# Stub ssh for check-weights.sh. The worker model path equals the head's.
+# Everything before the ssh host argument is ignored; the rest runs locally,
+# so remote mktemp, python and rm -rf all execute for real on this machine.
 args=("\$@")
 hostpos=-1
 for i in "\${!args[@]}"; do
@@ -112,20 +112,28 @@ exit 0
 SSH
 cat > "$WORK/bin/scp" <<SCP
 #!/usr/bin/env bash
-# Stub scp: the worker files are pre-copied by the test harness.
-exit 0
+# Stub scp: copy src to dst, stripping any host: prefix and skipping flags,
+# so the worker temp dir flow behaves like the real one.
+args=()
+for a in "\$@"; do
+    case "\$a" in
+        -*) continue ;;
+        *) args+=("\$a") ;;
+    esac
+done
+src="\${args[0]}"
+dst="\${args[1]}"
+dst="\${dst#*:}"
+cp "\$src" "\$dst"
 SCP
 chmod +x "$WORK/bin/ssh" "$WORK/bin/scp"
-
-# Pre-copy to the "worker" (this machine) so the stubbed remote command works.
-cp "$REPO_ROOT/verify-weights.py" /tmp/verify-weights.py
-cp "$WORK/manifest.json" /tmp/verify-manifest.json
 
 # --- .env for check-weights.sh ----------------------------------------------
 cat > .env <<ENV
 HEAD_IP=10.0.0.1
 WORKER_IP=10.0.0.2
 MODEL_ID=org/model
+IFACE=eth0
 HF_HOME=$HF_HOME
 ENV
 

--- a/tests/test_verify_weights.py
+++ b/tests/test_verify_weights.py
@@ -1,0 +1,144 @@
+"""Tests for verify-weights.py.
+
+Runs against a tiny fake model directory and a stubbed manifest so no network
+access is needed, plus an integration path that maps a "snapshots/<rev>/..."
+local layout onto manifest relative paths.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+os.chdir(REPO_ROOT)
+
+# verify-weights.py has a hyphen, so it cannot be imported by name; load it
+# from its path instead.
+import importlib.util  # noqa: E402
+
+_SPEC = importlib.util.spec_from_file_location(
+    "verify_weights", os.path.join(REPO_ROOT, "verify-weights.py"))
+vw = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(vw)  # noqa: E402
+
+
+def make_file(path, size, content=None):
+    """Write a file of the requested size; content must fill the size exactly."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        if content is not None:
+            f.write(content)
+        else:
+            f.write(b"\x00" * size)
+    return path
+
+
+class VerifyWeightsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_ok_files(self):
+        """Expected use: all files present with matching size and hash."""
+        data = b"hello world"
+        make_file(os.path.join(self.tmp, "config.json"), len(data), data)
+        manifest = {
+            "config.json": {"type": "file", "size": len(data), "lfs": {"oid": ""}},
+            "model-00001.safetensors": {
+                "type": "file",
+                "size": len(data),
+                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
+                    os.path.join(self.tmp, "model-00001.safetensors"), len(data), data))},
+            },
+        }
+        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(missing, [])
+        self.assertEqual(size_mismatch, [])
+        self.assertEqual(hash_mismatch, [])
+
+    def test_missing_file(self):
+        """Failure case: a file in the manifest is absent locally."""
+        make_file(os.path.join(self.tmp, "config.json"), 5)
+        manifest = {
+            "config.json": {"type": "file", "size": 5, "lfs": {"oid": ""}},
+            "model.safetensors": {"type": "file", "size": 10, "lfs": {"oid": "sha256:abc"}},
+        }
+        missing, _, _ = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(missing, ["model.safetensors"])
+
+    def test_size_mismatch(self):
+        """Failure case: same path, different size."""
+        make_file(os.path.join(self.tmp, "config.json"), 100)
+        manifest = {
+            "config.json": {"type": "file", "size": 50, "lfs": {"oid": ""}},
+        }
+        _, size_mismatch, _ = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(size_mismatch, ["config.json"])
+
+    def test_hash_mismatch(self):
+        """Failure case: same size, different content hash."""
+        data_a = b"A" * 16
+        data_b = b"B" * 16
+        make_file(os.path.join(self.tmp, "model.safetensors"), 16, data_b)
+        manifest = {
+            "model.safetensors": {
+                "type": "file",
+                "size": 16,
+                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
+                    os.path.join(self.tmp, "expected.safetensors"), 16, data_a))},
+            },
+        }
+        _, _, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(hash_mismatch, ["model.safetensors"])
+
+    def test_snapshot_prefix_stripped(self):
+        """Edge case: standard hub layout uses snapshots/<rev>/ prefix."""
+        data = b"weights"
+        # Build the manifest with plain relative paths.
+        oid = "sha256:" + vw.file_sha256(make_file(
+            os.path.join(self.tmp, "snapshots/abc123", "model.safetensors"),
+            len(data), data))
+        manifest = {
+            "model.safetensors": {"type": "file", "size": len(data), "lfs": {"oid": oid}},
+        }
+        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual((missing, size_mismatch, hash_mismatch), ([], [], []))
+
+    def test_ignores_download_artifacts(self):
+        """Edge case: lock files and download artifacts are not treated as missing."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 10)
+        make_file(os.path.join(self.tmp, "model.safetensors.lock"), 3)
+        make_file(os.path.join(self.tmp, "download", "junk.incomplete"), 3)
+        manifest = {
+            "model.safetensors": {"type": "file", "size": 10, "lfs": {"oid": ""}},
+        }
+        missing, _, _ = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(missing, [])
+
+    def test_manifest_save_and_load(self):
+        """Expected use: a saved manifest round-trips and drives verification."""
+        data = b"weights"
+        manifest = {
+            "model.safetensors": {
+                "type": "file",
+                "size": len(data),
+                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
+                    os.path.join(self.tmp, "model.safetensors"), len(data), data))},
+            },
+        }
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest_file(manifest_path, manifest)
+        loaded = vw.load_manifest_file(manifest_path)
+        self.assertEqual(loaded, manifest)
+        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, loaded, workers=2)
+        self.assertEqual((missing, size_mismatch, hash_mismatch), ([], [], []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_weights.py
+++ b/tests/test_verify_weights.py
@@ -280,6 +280,29 @@ class VerifyWeightsTest(unittest.TestCase):
         rc = vw.main(["--repo", "org/model", "--fetch-only", "--manifest", "/nope.json", "--quiet"])
         self.assertEqual(rc, 2)
 
+    def test_dry_run_skips_hashing(self):
+        """Expected use: dry-run reports size problems but not hash problems."""
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"WXYZ")  # same size, different content
+        # Real verify catches the hash mismatch.
+        full = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(full), ["HASH"])
+        # Dry run skips hashing but still checks presence + size (both fine).
+        dry = vw.verify(self.tmp, manifest, workers=2, hash_files=False)
+        self.assertEqual(dry, [])
+
+    def test_dry_run_cli_exit_0(self):
+        """Expected use: CLI --dry-run returns 0 for same-size different-content."""
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"WXYZ")
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest(manifest_path, manifest)
+        rc = vw.main(["--repo", "org/model", "--path", self.tmp,
+                      "--manifest", manifest_path, "--dry-run", "--quiet"])
+        self.assertEqual(rc, 0)
+
     def test_main_missing_model_dir_returns_2(self):
         """Failure case: verify without --path and no model dir gives exit 2."""
         with mock.patch.dict(os.environ, {"HF_HOME": self.tmp}):

--- a/tests/test_verify_weights.py
+++ b/tests/test_verify_weights.py
@@ -1,8 +1,8 @@
 """Tests for verify-weights.py.
 
-Runs against a tiny fake model directory and a stubbed manifest so no network
-access is needed, plus an integration path that maps a "snapshots/<rev>/..."
-local layout onto manifest relative paths.
+Runs against tiny fake model directories and stubbed manifests / HTTP responses
+so no network access is needed. Covers the expected path, every failure mode the
+verifier can report, and the resolution logic for the standard hub layout.
 """
 
 import os
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import unittest
 from unittest import mock
+from urllib.error import HTTPError, URLError
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
@@ -37,6 +38,25 @@ def make_file(path, size, content=None):
     return path
 
 
+def shas(root, files):
+    """Write the given files under root and return a valid manifest for them.
+
+    files maps relative path -> content bytes/str. Returns the manifest entries
+    (with correct size and LFS SHA-256) for those files.
+    """
+    manifest = {}
+    for rel, content in files.items():
+        path = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if isinstance(content, str):
+            content = content.encode()
+        with open(path, "wb") as f:
+            f.write(content)
+        manifest[rel] = {"type": "file", "size": len(content),
+                         "lfs": {"oid": "sha256:" + vw.file_sha256(path)}}
+    return manifest
+
+
 class VerifyWeightsTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -44,100 +64,336 @@ class VerifyWeightsTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
+    def kinds(self, problems):
+        """Return the multiset of problem kinds as a list."""
+        return sorted(p.kind for p in problems)
+
     def test_ok_files(self):
         """Expected use: all files present with matching size and hash."""
-        data = b"hello world"
-        make_file(os.path.join(self.tmp, "config.json"), len(data), data)
-        manifest = {
-            "config.json": {"type": "file", "size": len(data), "lfs": {"oid": ""}},
-            "model-00001.safetensors": {
-                "type": "file",
-                "size": len(data),
-                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
-                    os.path.join(self.tmp, "model-00001.safetensors"), len(data), data))},
-            },
-        }
-        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual(missing, [])
-        self.assertEqual(size_mismatch, [])
-        self.assertEqual(hash_mismatch, [])
+        make_file(os.path.join(self.tmp, "config.json"), 5, b"hello")
+        manifest = shas(self.tmp, {"config.json": b"hello"})
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
 
     def test_missing_file(self):
         """Failure case: a file in the manifest is absent locally."""
-        make_file(os.path.join(self.tmp, "config.json"), 5)
-        manifest = {
-            "config.json": {"type": "file", "size": 5, "lfs": {"oid": ""}},
-            "model.safetensors": {"type": "file", "size": 10, "lfs": {"oid": "sha256:abc"}},
-        }
-        missing, _, _ = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual(missing, ["model.safetensors"])
+        manifest = shas(self.tmp, {"config.json": b"hello"})
+        manifest["model.safetensors"] = {"type": "file", "size": 10, "lfs": {"oid": ""}}
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(problems), ["MISSING"])
+        self.assertEqual(problems[0].rel, "model.safetensors")
 
     def test_size_mismatch(self):
         """Failure case: same path, different size."""
-        make_file(os.path.join(self.tmp, "config.json"), 100)
-        manifest = {
-            "config.json": {"type": "file", "size": 50, "lfs": {"oid": ""}},
-        }
-        _, size_mismatch, _ = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual(size_mismatch, ["config.json"])
+        manifest = shas(self.tmp, {"model.safetensors": b"A" * 15})
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"B" * 16)  # same path, different size than the manifest
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        # The size differs AND the hash differs; both are reported.
+        self.assertEqual(self.kinds(problems), ["HASH", "SIZE"])
+        self.assertIn("15 bytes", problems[0].detail)
+        self.assertIn("16", problems[0].detail)
 
     def test_hash_mismatch(self):
         """Failure case: same size, different content hash."""
-        data_a = b"A" * 16
-        data_b = b"B" * 16
-        make_file(os.path.join(self.tmp, "model.safetensors"), 16, data_b)
-        manifest = {
-            "model.safetensors": {
-                "type": "file",
-                "size": 16,
-                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
-                    os.path.join(self.tmp, "expected.safetensors"), 16, data_a))},
-            },
-        }
-        _, _, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual(hash_mismatch, ["model.safetensors"])
+        manifest = shas(self.tmp, {"model.safetensors": b"A" * 16})
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"B" * 16)  # same size, different content
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(problems), ["HASH"])
+        self.assertEqual(problems[0].rel, "model.safetensors")
 
-    def test_snapshot_prefix_stripped(self):
-        """Edge case: standard hub layout uses snapshots/<rev>/ prefix."""
-        data = b"weights"
-        # Build the manifest with plain relative paths.
-        oid = "sha256:" + vw.file_sha256(make_file(
-            os.path.join(self.tmp, "snapshots/abc123", "model.safetensors"),
-            len(data), data))
+    def test_multiple_problems_reported(self):
+        """Failure case: one bad run reports every problem, not just the first."""
+        make_file(os.path.join(self.tmp, "present.safetensors"), 4, b"WXYZ")
+        make_file(os.path.join(self.tmp, "wrong-size.safetensors"), 4, b"WXYZ")
         manifest = {
-            "model.safetensors": {"type": "file", "size": len(data), "lfs": {"oid": oid}},
+            "present.safetensors": {"type": "file", "size": 4,
+                                    "lfs": {"oid": "sha256:" + vw.file_sha256(
+                                        os.path.join(self.tmp, "present.safetensors"))}},
+            "wrong-size.safetensors": {"type": "file", "size": 9, "lfs": {"oid": ""}},
+            "missing.safetensors": {"type": "file", "size": 1, "lfs": {"oid": ""}},
         }
-        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual((missing, size_mismatch, hash_mismatch), ([], [], []))
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(problems), ["MISSING", "SIZE"])
+
+    def test_empty_file_matches_when_oid_blank(self):
+        """Edge case: an empty manifest-verified file with no LFS oid is fine."""
+        make_file(os.path.join(self.tmp, "empty.json"), 0)
+        manifest = {"empty.json": {"type": "file", "size": 0, "lfs": {"oid": ""}}}
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_oid_sha256_prefix_optional(self):
+        """Edge case: oid with and without the sha256: prefix both work."""
+        make_file(os.path.join(self.tmp, "a.safetensors"), 4, b"abcd")
+        make_file(os.path.join(self.tmp, "b.safetensors"), 4, b"efgh")
+        manifest = {
+            "a.safetensors": {"type": "file", "size": 4,
+                              "lfs": {"oid": vw.file_sha256(os.path.join(self.tmp, "a.safetensors"))}},
+            "b.safetensors": {"type": "file", "size": 4,
+                              "lfs": {"oid": "sha256:" + vw.file_sha256(os.path.join(self.tmp, "b.safetensors"))}},
+        }
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
 
     def test_ignores_download_artifacts(self):
         """Edge case: lock files and download artifacts are not treated as missing."""
-        make_file(os.path.join(self.tmp, "model.safetensors"), 10)
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
         make_file(os.path.join(self.tmp, "model.safetensors.lock"), 3)
         make_file(os.path.join(self.tmp, "download", "junk.incomplete"), 3)
+        make_file(os.path.join(self.tmp, "refs", "main"), 0)
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_dangling_symlink_reported(self):
+        """Failure case: a snapshot symlink that points nowhere is reported."""
+        os.makedirs(os.path.join(self.tmp, "snapshots", "abc123"))
+        os.symlink("/nonexistent/target", os.path.join(self.tmp, "snapshots", "abc123", "model.safetensors"))
         manifest = {
             "model.safetensors": {"type": "file", "size": 10, "lfs": {"oid": ""}},
         }
-        missing, _, _ = vw.verify(self.tmp, manifest, workers=2)
-        self.assertEqual(missing, [])
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        # The broken symlink is unusable, so the manifest file is effectively missing too.
+        self.assertEqual(self.kinds(problems), ["BROKEN", "MISSING"])
 
-    def test_manifest_save_and_load(self):
+    def test_unreadable_file_reported(self):
+        """Failure case: an unreadable file (permissions) is reported, not crashed."""
+        path = os.path.join(self.tmp, "model.safetensors")
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        os.chmod(path, 0o000)
+        try:
+            problems = vw.verify(self.tmp, manifest, workers=2)
+            self.assertEqual(self.kinds(problems), ["UNREADABLE"])
+        finally:
+            os.chmod(path, 0o644)
+
+    def test_manifest_missing_key_skipped(self):
+        """Edge case: manifest entries without 'size' are still checked for hash."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        del manifest["model.safetensors"]["size"]
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_symlink_cycle_terminates(self):
+        """Edge case: a symlink cycle in the tree does not hang the walk."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
+        os.symlink(self.tmp, os.path.join(self.tmp, "loop"))
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_resolve_snapshot_uses_refs_main(self):
+        """Expected use: hub layout resolves the snapshot pointed to by refs/main."""
+        snap = os.path.join(self.tmp, "snapshots", "rev2")
+        make_file(os.path.join(snap, "model.safetensors"), 4, b"abcd")
+        os.makedirs(os.path.join(self.tmp, "snapshots", "rev1"))
+        os.makedirs(os.path.join(self.tmp, "refs"))
+        with open(os.path.join(self.tmp, "refs", "main"), "w") as f:
+            f.write("rev2\n")  # trailing newline like huggingface_hub >= 1.x
+        tree_dir, is_snapshot = vw.resolve_snapshot(self.tmp)
+        self.assertTrue(is_snapshot)
+        self.assertEqual(os.path.basename(tree_dir), "rev2")
+
+    def test_resolve_snapshot_single(self):
+        """Edge case: only one snapshot exists; it is used even without refs/main."""
+        snap = os.path.join(self.tmp, "snapshots", "rev1")
+        make_file(os.path.join(snap, "model.safetensors"), 4, b"abcd")
+        tree_dir, is_snapshot = vw.resolve_snapshot(self.tmp)
+        self.assertTrue(is_snapshot)
+        self.assertEqual(os.path.basename(tree_dir), "rev1")
+
+    def test_resolve_snapshot_multiple_no_refs_raises(self):
+        """Failure case: multiple snapshots and no usable refs/main is an error."""
+        os.makedirs(os.path.join(self.tmp, "snapshots", "rev1"))
+        os.makedirs(os.path.join(self.tmp, "snapshots", "rev2"))
+        with self.assertRaises(vw.VerifierError):
+            vw.resolve_snapshot(self.tmp)
+
+    def test_resolve_snapshot_refs_points_missing_raises(self):
+        """Failure case: refs/main points at a revision that does not exist."""
+        os.makedirs(os.path.join(self.tmp, "snapshots", "rev1"))
+        os.makedirs(os.path.join(self.tmp, "snapshots", "rev2"))
+        os.makedirs(os.path.join(self.tmp, "refs"))
+        with open(os.path.join(self.tmp, "refs", "main"), "w") as f:
+            f.write("rev3")
+        with self.assertRaises(vw.VerifierError):
+            vw.resolve_snapshot(self.tmp)
+
+    def test_manifest_save_and_load_roundtrip(self):
         """Expected use: a saved manifest round-trips and drives verification."""
-        data = b"weights"
-        manifest = {
-            "model.safetensors": {
-                "type": "file",
-                "size": len(data),
-                "lfs": {"oid": "sha256:" + vw.file_sha256(make_file(
-                    os.path.join(self.tmp, "model.safetensors"), len(data), data))},
-            },
-        }
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
         manifest_path = os.path.join(self.tmp, "manifest.json")
-        vw.save_manifest_file(manifest_path, manifest)
-        loaded = vw.load_manifest_file(manifest_path)
+        vw.save_manifest(manifest_path, manifest)
+        loaded = vw.load_manifest(manifest_path)
         self.assertEqual(loaded, manifest)
-        missing, size_mismatch, hash_mismatch = vw.verify(self.tmp, loaded, workers=2)
-        self.assertEqual((missing, size_mismatch, hash_mismatch), ([], [], []))
+        problems = vw.verify(self.tmp, loaded, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_load_manifest_malformed_raises(self):
+        """Failure case: a corrupt manifest file raises VerifierError."""
+        bad = os.path.join(self.tmp, "bad.json")
+        with open(bad, "w") as f:
+            f.write("{not json")
+        with self.assertRaises(vw.VerifierError):
+            vw.load_manifest(bad)
+
+    def test_verify_with_workers_less_than_one(self):
+        """Edge case: workers=0 or negative falls back to 1 without error."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        self.assertEqual(vw.verify(self.tmp, manifest, workers=0), [])
+
+    def test_fetch_manifest_http_error(self):
+        """Failure case: an HTTP error from the API raises VerifierError with a message."""
+        with mock.patch.object(vw.urllib.request, "urlopen",
+                               side_effect=HTTPError("url", 404, "Not Found", None, None)):
+            with self.assertRaises(vw.VerifierError) as ctx:
+                vw.fetch_manifest("org/model", "main")
+        self.assertIn("404", str(ctx.exception))
+
+    def test_fetch_manifest_network_error(self):
+        """Failure case: a network error (timeout, DNS) raises VerifierError."""
+        with mock.patch.object(vw.urllib.request, "urlopen",
+                               side_effect=URLError("connection refused")):
+            with self.assertRaises(vw.VerifierError):
+                vw.fetch_manifest("org/model", "main")
+
+    def test_fetch_manifest_garbage_payload(self):
+        """Failure case: a non-list API response raises instead of crashing."""
+        with mock.patch.object(vw.urllib.request, "urlopen",
+                               side_effect=json_response({"oops": True})):
+            with self.assertRaises(vw.VerifierError):
+                vw.fetch_manifest("org/model", "main")
+
+    def test_fetch_only_does_not_need_model_dir(self):
+        """Expected use: --fetch-only succeeds even when no model dir exists."""
+        with mock.patch.object(vw, "fetch_manifest", return_value={}):
+            rc = vw.main(["--repo", "org/model", "--fetch-only", "--quiet"])
+        self.assertEqual(rc, 0)
+
+    def test_fetch_only_rejects_manifest(self):
+        """Failure case: --fetch-only with --manifest is an argument error (exit 2)."""
+        rc = vw.main(["--repo", "org/model", "--fetch-only", "--manifest", "/nope.json", "--quiet"])
+        self.assertEqual(rc, 2)
+
+    def test_main_missing_model_dir_returns_2(self):
+        """Failure case: verify without --path and no model dir gives exit 2."""
+        with mock.patch.dict(os.environ, {"HF_HOME": self.tmp}):
+            rc = vw.main(["--repo", "org/model", "--quiet", "--manifest", "x"])
+        self.assertEqual(rc, 2)
+
+    def test_main_verify_ok(self):
+        """Expected use: full CLI verify returns 0 for a valid tree + saved manifest."""
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest(manifest_path, manifest)
+        rc = vw.main(["--repo", "org/model", "--path", self.tmp,
+                      "--manifest", manifest_path, "--quiet"])
+        self.assertEqual(rc, 0)
+
+    def test_main_verify_failure_returns_1(self):
+        """Failure case: a corrupt file makes the CLI exit 1."""
+        manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"wxyz")  # 4 bytes, different content
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest(manifest_path, manifest)
+        rc = vw.main(["--repo", "org/model", "--path", self.tmp,
+                      "--manifest", manifest_path, "--quiet"])
+        self.assertEqual(rc, 1)
+
+    def test_gitattributes_is_a_real_file_verified(self):
+        """Edge case: .gitattributes is a manifest file and must be verified."""
+        manifest = shas(self.tmp, {".gitattributes": b"*.safetensors filter=lfs\n"})
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_manifest_empty_oid_hash_still_checked(self):
+        """Edge case: entries with an LFS oid present are hashed even if size matches."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
+        manifest = {
+            "model.safetensors": {"type": "file", "size": 4,
+                                  "lfs": {"oid": "sha256:" + vw.file_sha256(
+                                      os.path.join(self.tmp, "model.safetensors"))}},
+        }
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_lfs_null_and_absent_not_crash(self):
+        """Edge case: lfs null / absent in the manifest must not crash."""
+        make_file(os.path.join(self.tmp, "config.json"), 3, b"abc")
+        make_file(os.path.join(self.tmp, "model.bin"), 3, b"xyz")
+        manifest = {
+            "config.json": {"type": "file", "size": 3, "lfs": None},
+            "model.bin": {"type": "file", "size": 3},
+        }
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_uppercase_oid_prefix(self):
+        """Edge case: uppercase SHA256: prefix and hex are normalized."""
+        data = b"abcd"
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, data)
+        oid = vw.file_sha256(os.path.join(self.tmp, "model.safetensors"))
+        manifest = {
+            "model.safetensors": {"type": "file", "size": 4,
+                                  "lfs": {"oid": "SHA256:" + oid.upper()}},
+        }
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+
+    def test_same_size_rewrite_caught_by_hash(self):
+        """Failure case: a same-size rewrite (size ok) is still caught by hash."""
+        make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"ABCD")
+        manifest = {
+            "model.safetensors": {"type": "file", "size": 4,
+                                  "lfs": {"oid": "sha256:" + vw.file_sha256(
+                                      os.path.join(self.tmp, "model.safetensors"))}},
+        }
+        with open(os.path.join(self.tmp, "model.safetensors"), "wb") as f:
+            f.write(b"WXYZ")  # same size, different content
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(problems), ["HASH"])
+
+    def test_fetch_manifest_pagination(self):
+        """Expected use: a paginated API response is followed to completion."""
+        pages = [
+            ([{"type": "file", "path": "a.txt", "size": 1, "lfs": {"oid": ""}}], '<https://x?cursor=2>; rel="next"'),
+            ([{"type": "file", "path": "b.txt", "size": 1, "lfs": {"oid": ""}}], None),
+        ]
+        with mock.patch.object(
+            vw.urllib.request, "urlopen",
+            side_effect=[json_response(payload, link) for payload, link in pages]):
+            manifest = vw.fetch_manifest("org/model", "main")
+        self.assertEqual(set(manifest), {"a.txt", "b.txt"})
+
+
+class _FakeResp:
+    def __init__(self, payload, link=None):
+        self._payload = json.dumps(payload).encode()
+        self.headers = {}
+        if link:
+            self.headers["Link"] = link
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def json_response(payload, link=None):
+    return _FakeResp(payload, link)
+
+
+import json  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_weights.py
+++ b/tests/test_verify_weights.py
@@ -6,6 +6,7 @@ verifier can report, and the resolution logic for the standard hub layout.
 """
 
 import hashlib
+import json
 import os
 import shutil
 import sys
@@ -238,11 +239,42 @@ class VerifyWeightsTest(unittest.TestCase):
         make_file(os.path.join(self.tmp, "model.safetensors"), 4, b"abcd")
         manifest = shas(self.tmp, {"model.safetensors": b"abcd"})
         manifest_path = os.path.join(self.tmp, "manifest.json")
-        vw.save_manifest(manifest_path, manifest)
-        loaded = vw.load_manifest(manifest_path)
+        vw.save_manifest(manifest_path, manifest, "org/model", "main")
+        loaded, meta = vw.load_manifest(manifest_path)
         self.assertEqual(loaded, manifest)
+        self.assertEqual(meta.get("repo"), "org/model")
+        self.assertEqual(meta.get("revision"), "main")
+        self.assertTrue(meta.get("fetched_at"))
         problems = vw.verify(self.tmp, loaded, workers=2)
         self.assertEqual(problems, [])
+
+    def test_load_manifest_legacy_bare_mapping(self):
+        """Edge case: a manifest saved by an older version has no provenance."""
+        manifest = shas(self.tmp, {"config.json": b"{}"})
+        manifest_path = os.path.join(self.tmp, "legacy.json")
+        with open(manifest_path, "w") as handle:
+            json.dump(manifest, handle)
+        loaded, meta = vw.load_manifest(manifest_path)
+        self.assertEqual(loaded, manifest)
+        self.assertEqual(meta, {})
+
+    def test_main_manifest_wrong_repo_returns_2(self):
+        """Failure case: a manifest saved for another repo is refused, not verified."""
+        manifest = shas(self.tmp, {"config.json": b"{}"})
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest(manifest_path, manifest, "other/model", "main")
+        rc = vw.main(["--repo", "org/model", "--path", self.tmp,
+                      "--manifest", manifest_path, "--quiet"])
+        self.assertEqual(rc, 2)
+
+    def test_main_manifest_right_repo_verifies(self):
+        """Expected use: a manifest saved for this repo passes the cross-check."""
+        manifest = shas(self.tmp, {"config.json": b"{}"})
+        manifest_path = os.path.join(self.tmp, "manifest.json")
+        vw.save_manifest(manifest_path, manifest, "org/model", "main")
+        rc = vw.main(["--repo", "org/model", "--path", self.tmp,
+                      "--manifest", manifest_path, "--quiet"])
+        self.assertEqual(rc, 0)
 
     def test_load_manifest_malformed_raises(self):
         """Failure case: a corrupt manifest file raises VerifierError."""

--- a/tests/test_verify_weights.py
+++ b/tests/test_verify_weights.py
@@ -5,6 +5,7 @@ so no network access is needed. Covers the expected path, every failure mode the
 verifier can report, and the resolution logic for the standard hub layout.
 """
 
+import hashlib
 import os
 import shutil
 import sys
@@ -39,10 +40,11 @@ def make_file(path, size, content=None):
 
 
 def shas(root, files):
-    """Write the given files under root and return a valid manifest for them.
+    """Write the given files under root and return a manifest like the real API.
 
-    files maps relative path -> content bytes/str. Returns the manifest entries
-    (with correct size and LFS SHA-256) for those files.
+    files maps relative path -> content bytes/str. Shard like files get both
+    an lfs SHA-256 and a top level oid. Other files get only oid, the git blob
+    SHA-1, with no lfs key.
     """
     manifest = {}
     for rel, content in files.items():
@@ -52,8 +54,17 @@ def shas(root, files):
             content = content.encode()
         with open(path, "wb") as f:
             f.write(content)
-        manifest[rel] = {"type": "file", "size": len(content),
-                         "lfs": {"oid": "sha256:" + vw.file_sha256(path)}}
+        size = len(content)
+        if rel.endswith((".safetensors", ".bin", ".pt", ".onnx", ".h5")):
+            # Real LFS entries carry a pointer blob id in oid, not the content
+            # id, so use a dummy valid SHA-1 here. The verifier must prefer
+            # lfs.oid; a verifier that reads oid would fail on pristine files.
+            manifest[rel] = {"type": "file", "size": size,
+                             "oid": hashlib.sha1(b"pointer:" + content).hexdigest(),
+                             "lfs": {"oid": "sha256:" + vw.file_sha256(path)}}
+        else:
+            manifest[rel] = {"type": "file", "size": size,
+                             "oid": vw.file_git_sha1(path)}
     return manifest
 
 
@@ -381,6 +392,22 @@ class VerifyWeightsTest(unittest.TestCase):
             f.write(b"WXYZ")  # same size, different content
         problems = vw.verify(self.tmp, manifest, workers=2)
         self.assertEqual(self.kinds(problems), ["HASH"])
+
+    def test_non_lfs_same_size_rewrite_caught(self):
+        """Failure case: same size rewrite of a plain git file is caught."""
+        manifest = shas(self.tmp, {"config.json": b'{"a": 1}'})
+        with open(os.path.join(self.tmp, "config.json"), "wb") as f:
+            f.write(b'{"a": 2}')  # same size, different content
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(self.kinds(problems), ["HASH"])
+
+    def test_extra_file_does_not_fail(self):
+        """Edge case: a local file outside the manifest is extra, not a failure."""
+        manifest = shas(self.tmp, {"config.json": b"hello"})
+        make_file(os.path.join(self.tmp, "stray.safetensors"), 4, b"XXXX")
+        problems = vw.verify(self.tmp, manifest, workers=2)
+        self.assertEqual(problems, [])
+        self.assertEqual(vw.find_extras(self.tmp, manifest), ["stray.safetensors"])
 
     def test_fetch_manifest_pagination(self):
         """Expected use: a paginated API response is followed to completion."""

--- a/verify-weights.py
+++ b/verify-weights.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""verify-weights.py — Verify local model files against the Hugging Face tree manifest.
+
+Compares every file under the model directory against the manifest served by the
+Hugging Face API: presence, size, and (for LFS files) the content SHA-256. A
+size-only check does not catch a shard that was corrupted mid-download while
+keeping its apparent size wrong only by a few hundred MB (see issue #30); hashing
+the LFS blobs does.
+
+Only the Python 3 standard library is used, so the script runs on the head node
+and on worker nodes without installing anything.
+
+Usage:
+  python3 verify-weights.py [--repo MODEL_ID] [--path DIR] [--revision REV]
+                            [--manifest FILE] [--workers N] [--quiet]
+
+The manifest is fetched from the Hugging Face API unless --manifest points at
+a previously saved one. check-weights.sh --verify fetches it once on the head
+and ships it to the worker, so the worker validates against the same manifest
+without needing model-API access.
+
+Exit status is 0 when every file in the manifest is present, matches the
+manifest size, and (for LFS files) matches the manifest SHA-256. Files in the
+model directory that are not in the manifest (lock files, download artifacts,
+trees metadata, ...) are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.request
+
+API_TREE_URL = "https://huggingface.co/api/models/{repo}/tree/{revision}"
+
+# Directory names that are download machinery, not model content. "snapshots"
+# is deliberately kept: in the standard hub layout the model files live under
+# snapshots/<revision>/ and must be hashed, while the deduplicated blobs/ (which
+# the snapshot entries point at) would just be hashed twice if walked.
+IGNORED_DIRS = {".cache", ".git", "blobs", "refs"}
+IGNORED_SUFFIXES = (".lock", ".metadata", ".incomplete")
+IGNORED_FILES = {".gitignore", "CACHEDIR.TAG"}
+
+# Prefix to strip from paths found under a standard hub snapshot directory.
+SNAPSHOT_PREFIX = re.compile(r"^snapshots/[^/]+/")
+
+
+def fetch_manifest(repo: str, revision: str) -> dict[str, dict]:
+    """Fetch the full recursive file manifest for a repo revision.
+
+    Returns a mapping of relative path -> entry. Handles API pagination via the
+    Link header, following it until every page has been read.
+    """
+    manifest: dict[str, dict] = {}
+    url = API_TREE_URL.format(repo=repo, revision=revision) + "?recursive=true"
+    headers = {"User-Agent": "verify-weights"}
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    while url:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            payload = json.loads(resp.read())
+            link = resp.headers.get("Link", "")
+        for entry in payload:
+            if entry.get("type") == "file":
+                manifest[entry["path"]] = entry
+        # Follow the next-page cursor if the server paginated the result.
+        url = ""
+        if 'rel="next"' in link:
+            for part in link.split(","):
+                if 'rel="next"' in part:
+                    url = part[part.find("<") + 1 : part.find(">")]
+                    break
+    return manifest
+
+
+def load_manifest_file(path: str) -> dict[str, dict]:
+    """Load a manifest previously saved with --save-manifest."""
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_manifest_file(path: str, manifest: dict[str, dict]) -> None:
+    """Save a manifest for reuse by another node / later run."""
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle)
+
+
+def iter_model_files(root: str):
+    """Yield relative path and absolute path of every model file under root.
+
+    Under the standard hub layout the content lives in snapshots/<revision>/, so
+    that prefix is stripped to match the manifest paths. Direct-download caches
+    (files at the repo root) are used as-is.
+    """
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=True):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        for filename in filenames:
+            if filename in IGNORED_FILES or filename.endswith(IGNORED_SUFFIXES):
+                continue
+            abs_path = os.path.join(dirpath, filename)
+            rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
+            rel_path = SNAPSHOT_PREFIX.sub("", rel_path)
+            yield rel_path, abs_path
+
+
+def file_sha256(path: str) -> str:
+    """Return the hex SHA-256 of a file, streaming it in 1 MiB chunks."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify(root: str, manifest: dict[str, dict], workers: int) -> tuple[list, list, list]:
+    """Verify the model directory against the manifest.
+
+    Returns (missing, size_mismatch, hash_mismatch) lists of relative paths.
+    """
+    local = {rel: path for rel, path in iter_model_files(root)}
+    expected = set(manifest)
+    missing = sorted(expected - set(local))
+    size_mismatch = []
+
+    for rel in sorted(set(local) & expected):
+        expected_size = manifest[rel].get("size")
+        if expected_size is not None and os.path.getsize(local[rel]) != expected_size:
+            size_mismatch.append(rel)
+
+    # Only LFS files carry a content SHA-256 we can compare against.
+    hash_targets = [
+        (rel, manifest[rel]["lfs"]["oid"].removeprefix("sha256:"))
+        for rel in sorted(set(local) & expected)
+        if manifest[rel].get("lfs", {}).get("oid")
+    ]
+    hash_mismatch: list[str] = []
+    if hash_targets:
+        def check(item):
+            rel, expected_oid = item
+            actual_oid = file_sha256(local[rel])
+            return rel, actual_oid, expected_oid
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            for rel, actual_oid, expected_oid in pool.map(check, hash_targets):
+                if actual_oid != expected_oid:
+                    hash_mismatch.append(rel)
+
+    return missing, size_mismatch, hash_mismatch
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=None, help="HF repo id, e.g. RadixArk/Qwen3.8-Flash-Next-NVFP4")
+    parser.add_argument("--path", default=None, help="Local model directory (defaults to $HF_HOME/hub/models--ORG--NAME)")
+    parser.add_argument("--revision", default="main", help="HF revision (default: main)")
+    parser.add_argument("--manifest", default=None, help="Use this saved manifest file instead of fetching the API")
+    parser.add_argument("--save-manifest", default=None, help="Save the fetched manifest to this file")
+    parser.add_argument("--fetch-only", action="store_true",
+                        help="Fetch (and save) the manifest, then exit without verifying")
+    parser.add_argument("--workers", type=int, default=8, help="Parallel hash workers (default: 8)")
+    parser.add_argument("--quiet", action="store_true", help="Only print problems")
+    args = parser.parse_args(argv)
+
+    repo = args.repo or os.environ.get("MODEL_ID", "")
+    if not repo:
+        print("ERROR: pass --repo or set MODEL_ID", file=sys.stderr)
+        return 2
+
+    path = args.path
+    if not path:
+        hf_home = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+        org, _, name = repo.partition("/")
+        path = os.path.join(hf_home, "hub", f"models--{org}--{name}")
+
+    if args.fetch_only:
+        if args.manifest:
+            print("ERROR: --fetch-only cannot be combined with --manifest", file=sys.stderr)
+            return 2
+        try:
+            manifest = fetch_manifest(repo, args.revision)
+        except Exception as exc:
+            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
+            return 2
+        if args.save_manifest:
+            save_manifest_file(args.save_manifest, manifest)
+        if not args.quiet:
+            print(f"Manifest: {len(manifest)} files")
+        return 0
+
+    if not os.path.isdir(path):
+        print(f"ERROR: model directory not found: {path}", file=sys.stderr)
+        return 2
+
+    if args.manifest:
+        # The launcher needs the checksums without hashing anything locally.
+        if args.manifest:
+            print("ERROR: --fetch-only cannot be combined with --manifest", file=sys.stderr)
+            return 2
+        try:
+            manifest = fetch_manifest(repo, args.revision)
+        except Exception as exc:
+            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
+            return 2
+        if args.save_manifest:
+            save_manifest_file(args.save_manifest, manifest)
+        if not args.quiet:
+            print(f"Manifest: {len(manifest)} files")
+        return 0
+
+    if args.manifest:
+        try:
+            manifest = load_manifest_file(args.manifest)
+        except Exception as exc:  # IOError, malformed JSON
+            print(f"ERROR: could not load manifest {args.manifest}: {exc}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            manifest = fetch_manifest(repo, args.revision)
+        except Exception as exc:  # network errors, HTTP errors, malformed JSON
+            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
+            return 2
+        if args.save_manifest:
+            save_manifest_file(args.save_manifest, manifest)
+
+    expected_bytes = sum(e.get("size", 0) for e in manifest.values())
+    if not args.quiet:
+        print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB)")
+        print(f"Verifying {path} ...")
+        print("Hashing LFS files; this reads the full checkpoint and takes a while on first run.\n")
+
+    missing, size_mismatch, hash_mismatch = verify(path, manifest, args.workers)
+
+    problems = missing + size_mismatch + hash_mismatch
+    if problems:
+        for rel in missing:
+            print(f"MISSING   {rel}")
+        for rel in size_mismatch:
+            expected_size = manifest[rel].get("size")
+            actual_size = os.path.getsize(path + "/" + rel)
+            print(f"SIZE      {rel}: expected {expected_size} bytes, found {actual_size}")
+        for rel in hash_mismatch:
+            print(f"HASH      {rel}: SHA-256 does not match the manifest")
+        print(f"\n{len(problems)} problem(s) in {len(manifest)} expected files.")
+        return 1
+
+    if not args.quiet:
+        print(f"OK: {len(manifest)} files verified, all sizes and SHA-256 hashes match.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/verify-weights.py
+++ b/verify-weights.py
@@ -12,17 +12,26 @@ and on worker nodes without installing anything.
 
 Usage:
   python3 verify-weights.py [--repo MODEL_ID] [--path DIR] [--revision REV]
-                            [--manifest FILE] [--workers N] [--quiet]
+                            [--manifest FILE] [--save-manifest FILE] [--fetch-only]
+                            [--workers N] [--quiet]
 
 The manifest is fetched from the Hugging Face API unless --manifest points at
 a previously saved one. check-weights.sh --verify fetches it once on the head
 and ships it to the worker, so the worker validates against the same manifest
-without needing model-API access.
+without needing model-API access. HF_API_BASE overrides the API endpoint (used
+by tests and mirrors); HF_TOKEN authenticates private repos.
 
-Exit status is 0 when every file in the manifest is present, matches the
-manifest size, and (for LFS files) matches the manifest SHA-256. Files in the
-model directory that are not in the manifest (lock files, download artifacts,
-trees metadata, ...) are ignored.
+Exit status:
+  0  every manifest file is present, matches its size, and (for LFS files) its SHA-256
+  1  at least one problem was found (missing / size / hash / unreadable / broken link)
+  2  the manifest could not be obtained, the model directory could not be resolved,
+     or the snapshot revision could not be determined
+
+Files in the model directory that are not in the manifest (lock files, download
+artifacts, trees metadata, stale snapshots, ...) are reported as extras but are
+not failures. Under the standard hub layout, the verified tree is the snapshot
+that refs/main points to (or the only snapshot, or an explicit --path); the
+deduplicated blobs/ and other snapshots are not hashed twice.
 """
 
 from __future__ import annotations
@@ -32,43 +41,57 @@ import concurrent.futures
 import hashlib
 import json
 import os
-import re
 import sys
+import urllib.error
 import urllib.request
 
-API_TREE_URL = "https://huggingface.co/api/models/{repo}/tree/{revision}"
+API_BASE = os.environ.get("HF_API_BASE", "https://huggingface.co")
+API_TREE_URL = API_BASE + "/api/models/{repo}/tree/{revision}?recursive=true"
 
 # Directory names that are download machinery, not model content. "snapshots"
-# is deliberately kept: in the standard hub layout the model files live under
-# snapshots/<revision>/ and must be hashed, while the deduplicated blobs/ (which
-# the snapshot entries point at) would just be hashed twice if walked.
-IGNORED_DIRS = {".cache", ".git", "blobs", "refs"}
+# is handled explicitly (the verified tree is the selected snapshot); blobs/
+# holds the deduplicated blobs and must not be walked.
+IGNORED_DIRS = {".cache", ".git", "blobs"}
 IGNORED_SUFFIXES = (".lock", ".metadata", ".incomplete")
 IGNORED_FILES = {".gitignore", "CACHEDIR.TAG"}
 
-# Prefix to strip from paths found under a standard hub snapshot directory.
-SNAPSHOT_PREFIX = re.compile(r"^snapshots/[^/]+/")
+_EMPTY_OID = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+class VerifierError(Exception):
+    """Raised when the expected manifest or the model tree cannot be resolved."""
 
 
 def fetch_manifest(repo: str, revision: str) -> dict[str, dict]:
     """Fetch the full recursive file manifest for a repo revision.
 
     Returns a mapping of relative path -> entry. Handles API pagination via the
-    Link header, following it until every page has been read.
+    Link header, following it until every page has been read, and raises
+    VerifierError with a useful message on any HTTP or JSON failure.
     """
     manifest: dict[str, dict] = {}
-    url = API_TREE_URL.format(repo=repo, revision=revision) + "?recursive=true"
+    url = API_TREE_URL.format(repo=repo, revision=revision)
     headers = {"User-Agent": "verify-weights"}
     token = os.environ.get("HF_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     while url:
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            payload = json.loads(resp.read())
-            link = resp.headers.get("Link", "")
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                payload = json.loads(resp.read())
+                link = resp.headers.get("Link", "")
+        except urllib.error.HTTPError as exc:
+            raise VerifierError(
+                f"HTTP {exc.code} for {repo}@{revision} "
+                f"(repo not found, rate-limited, or auth required: {exc.reason})"
+            ) from exc
+        except Exception as exc:  # URLError, timeout, malformed JSON, ...
+            raise VerifierError(f"could not fetch {url}: {exc}") from exc
+        if not isinstance(payload, list):
+            raise VerifierError(f"unexpected manifest payload for {repo}@{revision}")
         for entry in payload:
-            if entry.get("type") == "file":
+            if isinstance(entry, dict) and entry.get("type") == "file":
                 manifest[entry["path"]] = entry
         # Follow the next-page cursor if the server paginated the result.
         url = ""
@@ -80,34 +103,107 @@ def fetch_manifest(repo: str, revision: str) -> dict[str, dict]:
     return manifest
 
 
-def load_manifest_file(path: str) -> dict[str, dict]:
+def load_manifest(path: str) -> dict[str, dict]:
     """Load a manifest previously saved with --save-manifest."""
-    with open(path, "r", encoding="utf-8") as handle:
-        return json.load(handle)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception as exc:  # IOError, malformed JSON
+        raise VerifierError(f"could not load manifest {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise VerifierError(f"manifest {path} is not a mapping of path -> entry")
+    return payload
 
 
-def save_manifest_file(path: str, manifest: dict[str, dict]) -> None:
+def save_manifest(path: str, manifest: dict[str, dict]) -> None:
     """Save a manifest for reuse by another node / later run."""
     with open(path, "w", encoding="utf-8") as handle:
         json.dump(manifest, handle)
 
 
-def iter_model_files(root: str):
-    """Yield relative path and absolute path of every model file under root.
+def resolve_snapshot(root: str) -> tuple[str, bool]:
+    """Return (tree_dir, is_snapshot) for the model directory root.
 
-    Under the standard hub layout the content lives in snapshots/<revision>/, so
-    that prefix is stripped to match the manifest paths. Direct-download caches
-    (files at the repo root) are used as-is.
+    The standard hub layout stores content under snapshots/<revision>/; a
+    direct-download cache stores files at the model root. When snapshots exist,
+    the revision pointed to by refs/main is preferred, falling back to the only
+    available snapshot. When multiple snapshots exist and the revision cannot
+    be resolved, that is an error: hashing the wrong (stale) snapshot would
+    produce false failures.
     """
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=True):
-        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
-        for filename in filenames:
-            if filename in IGNORED_FILES or filename.endswith(IGNORED_SUFFIXES):
+    snapshots = os.path.join(root, "snapshots")
+    if not os.path.isdir(snapshots):
+        return root, False
+
+    revision = None
+    refs_main = os.path.join(root, "refs", "main")
+    if os.path.isfile(refs_main):
+        # huggingface_hub >= 1.x writes this with a trailing newline; strip it
+        # (see README gotcha) before using the value as a directory name.
+        with open(refs_main, "r", encoding="utf-8") as handle:
+            revision = handle.read().strip()
+    if revision:
+        candidate = os.path.join(snapshots, revision)
+        if os.path.isdir(candidate):
+            return candidate, True
+
+    try:
+        entries = sorted(
+            os.path.join(snapshots, name)
+            for name in os.listdir(snapshots)
+            if os.path.isdir(os.path.join(snapshots, name))
+        )
+    except OSError as exc:
+        raise VerifierError(f"could not read snapshot dir {snapshots}: {exc}") from exc
+
+    if len(entries) == 1:
+        return entries[0], True
+    if not entries:
+        return root, False
+    raise VerifierError(
+        f"multiple snapshots under {snapshots} and refs/main is missing or points "
+        "at a nonexistent revision; pass --path to a specific snapshot"
+    )
+
+
+def iter_model_files(tree_dir: str) -> tuple[dict[str, str], list[str]]:
+    """Walk tree_dir and return (files, broken_links).
+
+    files maps manifest-relative path -> absolute path. Only real files are
+    yielded; dangling symlinks are recorded in broken_links. The walk follows
+    directory symlinks but tracks visited real paths, so symlink cycles (for
+    example a snapshot dir pointing back at the model root) terminate.
+    """
+    files: dict[str, str] = {}
+    broken: list[str] = []
+    visited: set[str] = set()
+    stack = [tree_dir]
+    while stack:
+        dirpath = stack.pop()
+        real = os.path.realpath(dirpath)
+        if real in visited:
+            continue
+        visited.add(real)
+        try:
+            names = sorted(os.listdir(dirpath))
+        except OSError as exc:
+            raise VerifierError(f"could not read directory {dirpath}: {exc}") from exc
+        for name in names:
+            path = os.path.join(dirpath, name)
+            if os.path.isdir(path):  # follows symlinks
+                if name not in IGNORED_DIRS:
+                    stack.append(path)
                 continue
-            abs_path = os.path.join(dirpath, filename)
-            rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
-            rel_path = SNAPSHOT_PREFIX.sub("", rel_path)
-            yield rel_path, abs_path
+            rel = os.path.relpath(path, tree_dir).replace(os.sep, "/")
+            if os.path.islink(path) and not os.path.exists(path):
+                broken.append(rel)
+                continue
+            if not os.path.isfile(path):
+                continue  # sockets, fifos, and other oddities are not model files
+            if name in IGNORED_FILES or name.endswith(IGNORED_SUFFIXES):
+                continue
+            files[rel] = path
+    return files, broken
 
 
 def file_sha256(path: str) -> str:
@@ -119,39 +215,97 @@ def file_sha256(path: str) -> str:
     return digest.hexdigest()
 
 
-def verify(root: str, manifest: dict[str, dict], workers: int) -> tuple[list, list, list]:
-    """Verify the model directory against the manifest.
+def expected_oid(entry: dict) -> str:
+    """Return the lowercase hex SHA-256 for a manifest entry ("" if none).
 
-    Returns (missing, size_mismatch, hash_mismatch) lists of relative paths.
+    Handles lfs being absent or null (regular git files, some API responses),
+    any-case "sha256:" prefix or none. Only non-empty LFS oids are hash-checked;
+    empty files are covered by the size check (their well-known hash is implied).
     """
-    local = {rel: path for rel, path in iter_model_files(root)}
+    lfs = entry.get("lfs") or {}
+    oid = lfs.get("oid", "") or ""
+    oid = oid.strip().lower()
+    # The HF API always uses a lowercase "sha256:" prefix; tolerate any case
+    # and a missing prefix so manifests from other sources also verify.
+    if oid.startswith("sha256:"):
+        oid = oid[len("sha256:"):]
+    if oid == _EMPTY_OID:
+        return ""  # an empty file has a well-known hash; size already covers it
+    return oid
+
+
+class Problem:
+    """A single verification problem, categorized for reporting."""
+
+    def __init__(self, kind: str, rel: str, detail: str = ""):
+        self.kind = kind
+        self.rel = rel
+        self.detail = detail
+
+
+def verify(tree_dir: str, manifest: dict[str, dict], workers: int) -> list[Problem]:
+    """Verify the model tree against the manifest and return all problems.
+
+    Every manifest entry is checked for presence; present files are checked for
+    size and, for entries carrying an LFS SHA-256, for content hash. Problems
+    are collected instead of raising, so one bad file does not hide another.
+    """
+    if workers < 1:
+        workers = 1
+
+    local, broken = iter_model_files(tree_dir)
     expected = set(manifest)
-    missing = sorted(expected - set(local))
-    size_mismatch = []
+    problems: list[Problem] = []
 
+    for rel in sorted(expected - set(local)):
+        problems.append(Problem("MISSING", rel))
+    for rel in broken:
+        problems.append(Problem("BROKEN", rel, "dangling symlink"))
+
+    # Per-file size / readability check. A file that cannot be opened or stat'd
+    # is reported and excluded from hashing (avoiding a duplicate error).
+    hashable: list[str] = []
     for rel in sorted(set(local) & expected):
-        expected_size = manifest[rel].get("size")
-        if expected_size is not None and os.path.getsize(local[rel]) != expected_size:
-            size_mismatch.append(rel)
+        path = local[rel]
+        entry = manifest[rel]
+        expected_size = entry.get("size")
+        try:
+            actual_size = os.path.getsize(path)
+        except OSError as exc:
+            problems.append(Problem("UNREADABLE", rel, str(exc)))
+            continue
+        if isinstance(expected_size, int) and actual_size != expected_size:
+            problems.append(
+                Problem("SIZE", rel, f"expected {expected_size} bytes, found {actual_size}")
+            )
+            # The size already differs, but a manifest side-by-side read can
+            # race with a writer; still hash it so a same-size rewrite is caught.
+        hashable.append(rel)
 
-    # Only LFS files carry a content SHA-256 we can compare against.
     hash_targets = [
-        (rel, manifest[rel]["lfs"]["oid"].removeprefix("sha256:"))
-        for rel in sorted(set(local) & expected)
-        if manifest[rel].get("lfs", {}).get("oid")
+        (rel, expected_oid(manifest[rel]))
+        for rel in hashable
+        if expected_oid(manifest[rel])
     ]
-    hash_mismatch: list[str] = []
     if hash_targets:
-        def check(item):
-            rel, expected_oid = item
-            actual_oid = file_sha256(local[rel])
-            return rel, actual_oid, expected_oid
-        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
-            for rel, actual_oid, expected_oid in pool.map(check, hash_targets):
-                if actual_oid != expected_oid:
-                    hash_mismatch.append(rel)
+        def check(item: tuple[str, str]) -> Problem | None:
+            rel, oid = item
+            expected_size = manifest[rel].get("size")
+            expected = expected_oid(manifest[rel])
+            try:
+                actual = file_sha256(local[rel])
+            except OSError as exc:
+                return Problem("UNREADABLE", rel, str(exc))
+            if actual != expected:
+                return Problem("HASH", rel, f"expected {expected[:12]}…, found {actual[:12]}…")
+            return None
 
-    return missing, size_mismatch, hash_mismatch
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            for outcome in pool.map(check, hash_targets):
+                if outcome is not None:
+                    problems.append(outcome)
+
+    return problems
 
 
 def main(argv: list[str]) -> int:
@@ -172,80 +326,76 @@ def main(argv: list[str]) -> int:
         print("ERROR: pass --repo or set MODEL_ID", file=sys.stderr)
         return 2
 
-    path = args.path
-    if not path:
-        hf_home = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
-        org, _, name = repo.partition("/")
-        path = os.path.join(hf_home, "hub", f"models--{org}--{name}")
-
     if args.fetch_only:
         if args.manifest:
             print("ERROR: --fetch-only cannot be combined with --manifest", file=sys.stderr)
             return 2
         try:
             manifest = fetch_manifest(repo, args.revision)
-        except Exception as exc:
-            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
+        except VerifierError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
             return 2
         if args.save_manifest:
-            save_manifest_file(args.save_manifest, manifest)
+            save_manifest(args.save_manifest, manifest)
         if not args.quiet:
             print(f"Manifest: {len(manifest)} files")
         return 0
 
-    if not os.path.isdir(path):
-        print(f"ERROR: model directory not found: {path}", file=sys.stderr)
+    if args.path:
+        tree_dir = args.path
+        # If --path names the model root under the hub layout with multiple
+        # snapshots, resolve which one to hash.
+        try:
+            tree_dir, _ = resolve_snapshot(args.path)
+        except VerifierError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+    else:
+        hf_home = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
+        org, _, name = repo.partition("/")
+        model_dir = os.path.join(hf_home, "hub", f"models--{org}--{name}")
+        if not os.path.isdir(model_dir):
+            print(f"ERROR: model directory not found: {model_dir}", file=sys.stderr)
+            return 2
+        try:
+            tree_dir, _ = resolve_snapshot(model_dir)
+        except VerifierError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    if not os.path.isdir(tree_dir):
+        print(f"ERROR: model directory not found: {tree_dir}", file=sys.stderr)
         return 2
 
     if args.manifest:
-        # The launcher needs the checksums without hashing anything locally.
-        if args.manifest:
-            print("ERROR: --fetch-only cannot be combined with --manifest", file=sys.stderr)
-            return 2
         try:
-            manifest = fetch_manifest(repo, args.revision)
-        except Exception as exc:
-            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
-            return 2
-        if args.save_manifest:
-            save_manifest_file(args.save_manifest, manifest)
-        if not args.quiet:
-            print(f"Manifest: {len(manifest)} files")
-        return 0
-
-    if args.manifest:
-        try:
-            manifest = load_manifest_file(args.manifest)
-        except Exception as exc:  # IOError, malformed JSON
-            print(f"ERROR: could not load manifest {args.manifest}: {exc}", file=sys.stderr)
+            manifest = load_manifest(args.manifest)
+        except VerifierError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
             return 2
     else:
         try:
             manifest = fetch_manifest(repo, args.revision)
-        except Exception as exc:  # network errors, HTTP errors, malformed JSON
-            print(f"ERROR: could not fetch manifest for {repo}@{args.revision}: {exc}", file=sys.stderr)
+        except VerifierError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
             return 2
         if args.save_manifest:
-            save_manifest_file(args.save_manifest, manifest)
+            save_manifest(args.save_manifest, manifest)
 
-    expected_bytes = sum(e.get("size", 0) for e in manifest.values())
+    expected_bytes = sum(e.get("size", 0) for e in manifest.values() if isinstance(e.get("size"), int))
     if not args.quiet:
         print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB)")
-        print(f"Verifying {path} ...")
+        print(f"Verifying {tree_dir} ...")
         print("Hashing LFS files; this reads the full checkpoint and takes a while on first run.\n")
 
-    missing, size_mismatch, hash_mismatch = verify(path, manifest, args.workers)
+    problems = verify(tree_dir, manifest, args.workers)
 
-    problems = missing + size_mismatch + hash_mismatch
     if problems:
-        for rel in missing:
-            print(f"MISSING   {rel}")
-        for rel in size_mismatch:
-            expected_size = manifest[rel].get("size")
-            actual_size = os.path.getsize(path + "/" + rel)
-            print(f"SIZE      {rel}: expected {expected_size} bytes, found {actual_size}")
-        for rel in hash_mismatch:
-            print(f"HASH      {rel}: SHA-256 does not match the manifest")
+        for p in problems:
+            line = f"{p.kind:<10} {p.rel}"
+            if p.detail:
+                line = f"{line} ({p.detail})"
+            print(line)
         print(f"\n{len(problems)} problem(s) in {len(manifest)} expected files.")
         return 1
 

--- a/verify-weights.py
+++ b/verify-weights.py
@@ -13,7 +13,7 @@ and on worker nodes without installing anything.
 Usage:
   python3 verify-weights.py [--repo MODEL_ID] [--path DIR] [--revision REV]
                             [--manifest FILE] [--save-manifest FILE] [--fetch-only]
-                            [--workers N] [--quiet]
+                            [--dry-run] [--workers N] [--quiet]
 
 The manifest is fetched from the Hugging Face API unless --manifest points at
 a previously saved one. check-weights.sh --verify fetches it once on the head
@@ -243,12 +243,15 @@ class Problem:
         self.detail = detail
 
 
-def verify(tree_dir: str, manifest: dict[str, dict], workers: int) -> list[Problem]:
+def verify(tree_dir: str, manifest: dict[str, dict], workers: int,
+           hash_files: bool = True) -> list[Problem]:
     """Verify the model tree against the manifest and return all problems.
 
     Every manifest entry is checked for presence; present files are checked for
     size and, for entries carrying an LFS SHA-256, for content hash. Problems
     are collected instead of raising, so one bad file does not hide another.
+    With hash_files=False (dry run) the SHA-256 pass is skipped, leaving only
+    the cheap presence/size checks.
     """
     if workers < 1:
         workers = 1
@@ -287,6 +290,8 @@ def verify(tree_dir: str, manifest: dict[str, dict], workers: int) -> list[Probl
         for rel in hashable
         if expected_oid(manifest[rel])
     ]
+    if not hash_files:
+        return problems
     if hash_targets:
         def check(item: tuple[str, str]) -> Problem | None:
             rel, oid = item
@@ -317,6 +322,8 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--save-manifest", default=None, help="Save the fetched manifest to this file")
     parser.add_argument("--fetch-only", action="store_true",
                         help="Fetch (and save) the manifest, then exit without verifying")
+    parser.add_argument("--dry-run", "-n", action="store_true",
+                        help="Resolve and check presence/size only, skip the SHA-256 pass")
     parser.add_argument("--workers", type=int, default=8, help="Parallel hash workers (default: 8)")
     parser.add_argument("--quiet", action="store_true", help="Only print problems")
     args = parser.parse_args(argv)
@@ -386,9 +393,12 @@ def main(argv: list[str]) -> int:
     if not args.quiet:
         print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB)")
         print(f"Verifying {tree_dir} ...")
-        print("Hashing LFS files; this reads the full checkpoint and takes a while on first run.\n")
+        if args.dry_run:
+            print("Dry run: checking presence and size only (no SHA-256 hashing).\n")
+        else:
+            print("Hashing LFS files; this reads the full checkpoint and takes a while on first run.\n")
 
-    problems = verify(tree_dir, manifest, args.workers)
+    problems = verify(tree_dir, manifest, args.workers, hash_files=not args.dry_run)
 
     if problems:
         for p in problems:
@@ -400,7 +410,10 @@ def main(argv: list[str]) -> int:
         return 1
 
     if not args.quiet:
-        print(f"OK: {len(manifest)} files verified, all sizes and SHA-256 hashes match.")
+        if args.dry_run:
+            print(f"OK: {len(manifest)} files present with matching sizes (SHA-256 hashing skipped).")
+        else:
+            print(f"OK: {len(manifest)} files verified, all sizes and SHA-256 hashes match.")
     return 0
 
 

--- a/verify-weights.py
+++ b/verify-weights.py
@@ -48,6 +48,7 @@ import hashlib
 import json
 import os
 import sys
+from datetime import datetime, timezone
 import urllib.error
 import urllib.request
 
@@ -62,6 +63,11 @@ IGNORED_SUFFIXES = (".lock", ".metadata", ".incomplete")
 IGNORED_FILES = {".gitignore", "CACHEDIR.TAG"}
 
 _EMPTY_OID = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# Saved manifests wrap the files mapping with provenance, so a later run can
+# tell which repo and revision the hashes belong to.
+MANIFEST_FORMAT = "verify-weights-manifest"
+MANIFEST_VERSION = 1
 
 # The tree API puts a git blob SHA-1 in the top-level "oid" of every file entry,
 # so its shape tells a usable digest from anything else.
@@ -114,8 +120,13 @@ def fetch_manifest(repo: str, revision: str) -> dict[str, dict]:
     return manifest
 
 
-def load_manifest(path: str) -> dict[str, dict]:
-    """Load a manifest previously saved with --save-manifest."""
+def load_manifest(path: str) -> tuple[dict[str, dict], dict]:
+    """Load a manifest previously saved with --save-manifest.
+
+    Returns (files, meta). Files maps relative path -> API entry. Meta holds
+    the repo, revision and fetch time recorded at save time, or {} for a
+    manifest saved by an older version, which carried no provenance.
+    """
     try:
         with open(path, "r", encoding="utf-8") as handle:
             payload = json.load(handle)
@@ -123,13 +134,33 @@ def load_manifest(path: str) -> dict[str, dict]:
         raise VerifierError(f"could not load manifest {path}: {exc}") from exc
     if not isinstance(payload, dict):
         raise VerifierError(f"manifest {path} is not a mapping of path -> entry")
-    return payload
+    if payload.get("format") == MANIFEST_FORMAT:
+        files = payload.get("files")
+        if not isinstance(files, dict):
+            raise VerifierError(f"manifest {path} has no files mapping")
+        meta = {key: payload.get(key, "") for key in ("repo", "revision", "fetched_at")}
+        return files, meta
+    return payload, {}
 
 
-def save_manifest(path: str, manifest: dict[str, dict]) -> None:
-    """Save a manifest for reuse by another node / later run."""
+def save_manifest(path: str, manifest: dict[str, dict],
+                   repo: str = "", revision: str = "") -> None:
+    """Save a manifest for reuse by another node / later run.
+
+    The repo and revision the manifest was fetched for travel with it, so a
+    later --manifest run can refuse a manifest saved for a different repo
+    instead of verifying one checkpoint against another one's hashes.
+    """
+    payload = {
+        "format": MANIFEST_FORMAT,
+        "version": MANIFEST_VERSION,
+        "repo": repo,
+        "revision": revision,
+        "fetched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "files": manifest,
+    }
     with open(path, "w", encoding="utf-8") as handle:
-        json.dump(manifest, handle)
+        json.dump(payload, handle)
 
 
 def resolve_snapshot(root: str) -> tuple[str, bool]:
@@ -413,7 +444,7 @@ def main(argv: list[str]) -> int:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
         if args.save_manifest:
-            save_manifest(args.save_manifest, manifest)
+            save_manifest(args.save_manifest, manifest, repo, args.revision)
         if not args.quiet:
             print(f"Manifest: {len(manifest)} files")
         return 0
@@ -444,12 +475,23 @@ def main(argv: list[str]) -> int:
         print(f"ERROR: model directory not found: {tree_dir}", file=sys.stderr)
         return 2
 
+    manifest_meta: dict = {}
     if args.manifest:
         try:
-            manifest = load_manifest(args.manifest)
+            manifest, manifest_meta = load_manifest(args.manifest)
         except VerifierError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
+        # A manifest saved for another repo would verify this checkpoint
+        # against the wrong hashes and report nonsense. Refuse it loudly.
+        # Manifests saved by older versions carry no repo and skip the check.
+        saved_repo = manifest_meta.get("repo", "")
+        if saved_repo and saved_repo != repo:
+            print(f"ERROR: manifest {args.manifest} was saved for repo "
+                  f"'{saved_repo}', not '{repo}'", file=sys.stderr)
+            return 2
+        if args.save_manifest:
+            save_manifest(args.save_manifest, manifest, repo, args.revision)
     else:
         try:
             manifest = fetch_manifest(repo, args.revision)
@@ -457,11 +499,16 @@ def main(argv: list[str]) -> int:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 2
         if args.save_manifest:
-            save_manifest(args.save_manifest, manifest)
+            save_manifest(args.save_manifest, manifest, repo, args.revision)
 
     expected_bytes = sum(e.get("size", 0) for e in manifest.values() if isinstance(e.get("size"), int))
     if not args.quiet:
-        print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB)")
+        saved_info = ""
+        if args.manifest and (manifest_meta.get("repo") or manifest_meta.get("fetched_at")):
+            saved_info = (f" (saved for {manifest_meta.get('repo', '?')}"
+                          f"@{manifest_meta.get('revision', '?')} "
+                          f"at {manifest_meta.get('fetched_at', '?')})")
+        print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB){saved_info}")
         print(f"Verifying {tree_dir} ...")
         if args.dry_run:
             print("Dry run: checking presence and size only (no content hashing).\n")

--- a/verify-weights.py
+++ b/verify-weights.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""verify-weights.py — Verify local model files against the Hugging Face tree manifest.
+"""verify-weights.py: Verify local model files against the Hugging Face tree manifest.
 
 Compares every file under the model directory against the manifest served by the
-Hugging Face API: presence, size, and (for LFS files) the content SHA-256. A
-size-only check does not catch a shard that was corrupted mid-download while
-keeping its apparent size wrong only by a few hundred MB (see issue #30); hashing
-the LFS blobs does.
+Hugging Face API: presence, size, and content hash. The hash method follows the
+way git stores the file. An LFS file carries its content SHA-256 in "lfs.oid". A
+plain git file carries its git blob SHA-1 in the top-level "oid". Each file is
+checked by exactly one of the two.
+
+A size-only check is not enough. It misses a shard corrupted mid-download whose
+size is wrong by a few hundred MB (see issue #30), and it misses a config.json
+rewritten at the same size. Hashing the content catches both.
 
 Only the Python 3 standard library is used, so the script runs on the head node
 and on worker nodes without installing anything.
@@ -22,16 +26,18 @@ without needing model-API access. HF_API_BASE overrides the API endpoint (used
 by tests and mirrors); HF_TOKEN authenticates private repos.
 
 Exit status:
-  0  every manifest file is present, matches its size, and (for LFS files) its SHA-256
+  0  every manifest file is present, its size matches, and its content digest
+     matches (SHA-256 for LFS files, git blob SHA-1 for plain git files)
   1  at least one problem was found (missing / size / hash / unreadable / broken link)
   2  the manifest could not be obtained, the model directory could not be resolved,
      or the snapshot revision could not be determined
 
-Files in the model directory that are not in the manifest (lock files, download
-artifacts, trees metadata, stale snapshots, ...) are reported as extras but are
-not failures. Under the standard hub layout, the verified tree is the snapshot
-that refs/main points to (or the only snapshot, or an explicit --path); the
-deduplicated blobs/ and other snapshots are not hashed twice.
+Files in the model directory that are not in the manifest (leftover shards,
+manual edits, stray downloads, ...) are listed as EXTRA. They are not failures
+and they never change the exit status. Under the standard hub layout, the
+verified tree is the snapshot that refs/main points to (or the only snapshot,
+or an explicit --path); the deduplicated blobs/ and other snapshots are not
+hashed twice.
 """
 
 from __future__ import annotations
@@ -56,6 +62,11 @@ IGNORED_SUFFIXES = (".lock", ".metadata", ".incomplete")
 IGNORED_FILES = {".gitignore", "CACHEDIR.TAG"}
 
 _EMPTY_OID = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# The tree API puts a git blob SHA-1 in the top-level "oid" of every file entry,
+# so its shape tells a usable digest from anything else.
+_SHA1_HEX_LEN = 40
+_HEX_DIGITS = frozenset("0123456789abcdef")
 
 
 class VerifierError(Exception):
@@ -215,8 +226,23 @@ def file_sha256(path: str) -> str:
     return digest.hexdigest()
 
 
+def file_git_sha1(path: str) -> str:
+    """Return the hex git blob SHA-1 of a file, streaming it in 1 MiB chunks.
+
+    Git hashes the text "blob <size>\\0" and then the content, so the size is
+    read first to build that header. This is the digest the tree API reports in
+    "oid" for a file that git stores directly instead of in LFS.
+    """
+    digest = hashlib.sha1()
+    digest.update(b"blob %d\0" % os.path.getsize(path))
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def expected_oid(entry: dict) -> str:
-    """Return the lowercase hex SHA-256 for a manifest entry ("" if none).
+    """Return the lowercase hex content SHA-256 from an entry's lfs.oid ("" if none).
 
     Handles lfs being absent or null (regular git files, some API responses),
     any-case "sha256:" prefix or none. Only non-empty LFS oids are hash-checked;
@@ -234,6 +260,35 @@ def expected_oid(entry: dict) -> str:
     return oid
 
 
+def expected_git_oid(entry: dict) -> str:
+    """Return the lowercase hex git blob SHA-1 from an entry's "oid" ("" if none).
+
+    For a plain git file this digest covers the file content, so it is the only
+    content check that file can ever get. For an LFS file it covers the pointer
+    text instead, so callers must prefer lfs.oid (see expected_digest).
+    """
+    oid = (entry.get("oid") or "").strip().lower()
+    if len(oid) != _SHA1_HEX_LEN or not _HEX_DIGITS.issuperset(oid):
+        return ""  # not a blob id, so there is nothing to compare against
+    return oid
+
+
+def expected_digest(entry: dict) -> tuple[str, str]:
+    """Return (algorithm, digest) for an entry, or ("", "") when it has none.
+
+    Every file is checked by exactly one method. The LFS SHA-256 wins, because
+    the top-level "oid" of an LFS file hashes the pointer text and not the
+    content. A plain git file has no usable lfs.oid, so its blob SHA-1 is used.
+    """
+    oid = expected_oid(entry)
+    if oid:
+        return "sha256", oid
+    blob = expected_git_oid(entry)
+    if blob:
+        return "sha1", blob
+    return "", ""
+
+
 class Problem:
     """A single verification problem, categorized for reporting."""
 
@@ -248,10 +303,12 @@ def verify(tree_dir: str, manifest: dict[str, dict], workers: int,
     """Verify the model tree against the manifest and return all problems.
 
     Every manifest entry is checked for presence; present files are checked for
-    size and, for entries carrying an LFS SHA-256, for content hash. Problems
-    are collected instead of raising, so one bad file does not hide another.
-    With hash_files=False (dry run) the SHA-256 pass is skipped, leaving only
-    the cheap presence/size checks.
+    size and, when the manifest supplies a digest, for content (SHA-256 for LFS
+    entries, git blob SHA-1 for plain git entries). Problems are collected
+    instead of raising, so one bad file does not hide another. With
+    hash_files=False (dry run) the hashing pass is skipped, leaving only the
+    cheap presence/size checks. Local files that the manifest does not list are
+    not problems; use find_extras() to report them.
     """
     if workers < 1:
         workers = 1
@@ -285,24 +342,26 @@ def verify(tree_dir: str, manifest: dict[str, dict], workers: int,
             # race with a writer; still hash it so a same-size rewrite is caught.
         hashable.append(rel)
 
-    hash_targets = [
-        (rel, expected_oid(manifest[rel]))
-        for rel in hashable
-        if expected_oid(manifest[rel])
-    ]
+    # Pick one digest method per file. Files the manifest gives no usable
+    # digest for stay out of this list and are covered by presence and size.
+    hash_targets: list[tuple[str, str, str]] = []
+    for rel in hashable:
+        algorithm, digest = expected_digest(manifest[rel])
+        if algorithm:
+            hash_targets.append((rel, algorithm, digest))
     if not hash_files:
         return problems
     if hash_targets:
-        def check(item: tuple[str, str]) -> Problem | None:
-            rel, oid = item
-            expected_size = manifest[rel].get("size")
-            expected = expected_oid(manifest[rel])
+        def check(item: tuple[str, str, str]) -> Problem | None:
+            """Hash one file the way the manifest describes it and compare."""
+            rel, algorithm, digest = item
             try:
-                actual = file_sha256(local[rel])
+                actual = (file_git_sha1(local[rel]) if algorithm == "sha1"
+                          else file_sha256(local[rel]))
             except OSError as exc:
                 return Problem("UNREADABLE", rel, str(exc))
-            if actual != expected:
-                return Problem("HASH", rel, f"expected {expected[:12]}…, found {actual[:12]}…")
+            if actual != digest:
+                return Problem("HASH", rel, f"expected {digest[:12]}…, found {actual[:12]}…")
             return None
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
@@ -311,6 +370,17 @@ def verify(tree_dir: str, manifest: dict[str, dict], workers: int,
                     problems.append(outcome)
 
     return problems
+
+
+def find_extras(tree_dir: str, manifest: dict[str, dict]) -> list[str]:
+    """Return sorted local paths that the manifest does not list.
+
+    Extras are stray files, not failures. Callers print them but keep the
+    exit status from verify.
+    """
+    local, _ = iter_model_files(tree_dir)
+    expected = set(manifest)
+    return sorted(set(local) - expected)
 
 
 def main(argv: list[str]) -> int:
@@ -323,7 +393,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--fetch-only", action="store_true",
                         help="Fetch (and save) the manifest, then exit without verifying")
     parser.add_argument("--dry-run", "-n", action="store_true",
-                        help="Resolve and check presence/size only, skip the SHA-256 pass")
+                        help="Resolve and check presence/size only, skip content hashing")
     parser.add_argument("--workers", type=int, default=8, help="Parallel hash workers (default: 8)")
     parser.add_argument("--quiet", action="store_true", help="Only print problems")
     args = parser.parse_args(argv)
@@ -394,11 +464,21 @@ def main(argv: list[str]) -> int:
         print(f"Manifest: {len(manifest)} files ({expected_bytes / 1e9:.1f} GB)")
         print(f"Verifying {tree_dir} ...")
         if args.dry_run:
-            print("Dry run: checking presence and size only (no SHA-256 hashing).\n")
+            print("Dry run: checking presence and size only (no content hashing).\n")
         else:
-            print("Hashing LFS files; this reads the full checkpoint and takes a while on first run.\n")
+            print("Hashing files; this reads the full checkpoint and takes a while on first run.\n")
 
     problems = verify(tree_dir, manifest, args.workers, hash_files=not args.dry_run)
+
+    # Extras are for info only and never change the exit status, so a walk
+    # failure here is ignored; verify already did its own walk.
+    try:
+        extras = find_extras(tree_dir, manifest)
+    except VerifierError:
+        extras = []
+    if extras and not args.quiet:
+        for rel in extras:
+            print(f"{'EXTRA':<10} {rel}")
 
     if problems:
         for p in problems:
@@ -411,9 +491,9 @@ def main(argv: list[str]) -> int:
 
     if not args.quiet:
         if args.dry_run:
-            print(f"OK: {len(manifest)} files present with matching sizes (SHA-256 hashing skipped).")
+            print(f"OK: {len(manifest)} files present with matching sizes (content hashing skipped).")
         else:
-            print(f"OK: {len(manifest)} files verified, all sizes and SHA-256 hashes match.")
+            print(f"OK: {len(manifest)} files verified, all sizes and content hashes match.")
     return 0
 
 


### PR DESCRIPTION
## Summary

Addresses the actionable items from #30 (does not close it; #30 is a broad validation report):

- **Per-file content verification.** #30 reported a shard corrupted mid-download that a total-size check missed; the engine died at ~33% weight load. Adds `verify-weights.py` (stdlib-only) and `check-weights.sh --verify`, which fetches the HF manifest once on the head and hashes every file on both nodes against it: SHA-256 for LFS shards, git blob SHA-1 for plain files (`config.json`, tokenizer files, the safetensors index), which a size-only check leaves unverified.
- **Offline / air-gapped support.** `--manifest FILE` verifies against a manifest saved where the API is reachable (`python3 verify-weights.py --repo ID --save-manifest manifest.json --fetch-only`), so nodes behind a proxy/GFW never need to reach huggingface.co. `HF_API_BASE` in `.env` points the fetch at a mirror. Saved manifests carry repo, revision and fetch time; `--manifest` refuses a manifest saved for a different repo (exit 2) instead of verifying one checkpoint against another one's hashes.
- **`--dry-run`**: fetches the manifest, resolves paths, checks presence + size without hashing or scp - safe while the cluster is busy.
- **Path resolution:** `check-weights.sh` resolves the model directory with the same hub-path logic as `start.sh` on both head and worker, and honors a `WORKER_MODEL_PATH` override in `.env` for clusters that use different absolute roots per node. It deliberately does not guess beyond that: a verifier that checks the wrong tree is worse than one that reports it missing. Worker SSH failure no longer aborts the head check.
- **Temp hygiene:** fetched manifests go to mktemp files with cleanup on exit, and the worker gets a fresh private temp dir per run instead of fixed `/tmp` paths.
- **Exit codes you can act on:** 1 means the weights failed verification, anything else nonzero means the check itself broke. `check-weights.sh` reports the two differently instead of printing "mismatch" for both.
- **Docs:** `IB_GID_INDEX=5` fallback, huggingface_hub >= 1.x trailing-newline gotcha, weights-corruption warning, Docker Hub air-gap note, Scripts table.
- **Tests:** 40 unit tests covering every failure mode plus 12 shell-level tests for `check-weights.sh --verify` / `--dry-run` / `--manifest`.

## Validation

- Real cluster (2x DGX Spark, this repo's head + worker), before the review fixes: `./check-weights.sh --verify --manifest manifest.json` → **419 files / 135.3 GB, exit 0** (~2 min, offline). Worth one re-run after merge since the verifier now also hashes the 211 non-LFS files.
- `--dry-run` on the head against the real model: ~8s, presence + size only.
- Full unit + shell test suites pass (40 + 12).

## Commits

6 commits on `feature/issue-30-weights-verification`:
1. `feat: add per-file SHA-256 weights verification and doc fixes`
2. `test: harden weights verifier and cover all failure modes`
3. `feat: add --dry-run to weights verification and fix direct-layout resolution`
4. `feat: support offline verification with a saved manifest`
5. `fix: hash non-LFS manifest files via git blob SHA-1`
6. `fix: close review gaps in weights verification`

Refs: #30 (not closed by this PR)
