### PR TITLE
Accept FP8_PB_WO as an alias of FP8_BLOCK_SCALES for MTP routed experts (fixes #38, part of #37)

### DIFF
--- a/files/patch_checkpoint_config.py
+++ b/files/patch_checkpoint_config.py
@@ -81,10 +81,13 @@ def add_aliases(quant_config: dict, num_hidden_layers: int) -> bool:
 # RoutedExperts algos ModelOptMixedPrecisionConfig.get_quant_method can build.
 # Anything else resolves to a *silently unquantized* MoE, which then dies at load
 # with "has no parameter 'w2_weight_scale_inv'".
+# FP8_PB_WO is ModelOpt's newer name for the same 128x128 block-scaled FP8 weights
+# (nvidia/Qwen3.8-Flash-Next-NVFP4 commit fc694b54, 2026-09-05, renamed it in
+# config.json only; hf_quant_config.json still says FP8_BLOCK_SCALES).
 # FP8_BLOCK_SCALES is supported only because files/patch_modelopt_fp8_block_moe.py
 # adds that branch; stock vLLM (image and upstream main) would build an
 # unquantized MoE and die at load.
-SUPPORTED_MOE_ALGOS = {"FP8", "NVFP4", "W4A16_NVFP4", "MXFP8", "FP8_BLOCK_SCALES"}
+SUPPORTED_MOE_ALGOS = {"FP8", "NVFP4", "W4A16_NVFP4", "MXFP8", "FP8_BLOCK_SCALES", "FP8_PB_WO"}
 
 
 def mtp_moe_algo(snapshot_dir: str) -> str:

--- a/files/patch_modelopt_fp8_block_moe.py
+++ b/files/patch_modelopt_fp8_block_moe.py
@@ -80,15 +80,16 @@ DISPATCH = """            if quant_algo == "MXFP8":
                     quant_config=self.mxfp8_config,
                     moe_config=layer.moe_config,
                 )
-            if quant_algo == "FP8_BLOCK_SCALES":
+            if quant_algo in ("FP8_BLOCK_SCALES", "FP8_PB_WO"):
                 # Imported lazily: modelopt.py deliberately does not import fp8.py
                 # at module scope.
                 from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
 
                 logger.info_once(
-                    "Routed experts %s use FP8_BLOCK_SCALES; building them with "
+                    "Routed experts %s use %s; building them with "
                     "Fp8MoEMethod (block-quantized).",
                     prefix,
+                    quant_algo,
                 )
                 return Fp8MoEMethod(
                     quant_config=self._fp8_block_scales_config(prefix),
@@ -104,10 +105,21 @@ def _replace_once(src: str, old: str, new: str, what: str) -> str:
     return src.replace(old, new)
 
 
+NEW_BRANCH = 'if quant_algo in ("FP8_BLOCK_SCALES", "FP8_PB_WO"):'
+OLD_BRANCH = 'if quant_algo == "FP8_BLOCK_SCALES":'
+
+
 def patch() -> None:
     src = open(TARGET).read()
-    if "FP8_BLOCK_SCALES" in src:
+    if NEW_BRANCH in src:
         print("already patched", TARGET)
+        return
+    if OLD_BRANCH in src:
+        # Patched by an earlier version of this script: widen the branch to the
+        # FP8_PB_WO alias without re-applying the helper.
+        src = _replace_once(src, OLD_BRANCH, NEW_BRANCH, "moe dispatch (alias upgrade)")
+        open(TARGET, "w").write(src)
+        print("upgraded (FP8_PB_WO alias)", TARGET)
         return
     src = _replace_once(src, ANCHOR_HELPER, HELPER + ANCHOR_HELPER, "helper")
     src = _replace_once(src, ANCHOR_DISPATCH, DISPATCH, "moe dispatch")


### PR DESCRIPTION
## Description and Motivation

`nvidia/Qwen3.8-Flash-Next-NVFP4` was re-exported on 2026-09-05 (hub commit `fc694b54`, "Fix MTP serving metadata and instructions"). That commit changed exactly one line: the MTP routed experts' `quant_algo` in `config.json` went from `FP8_BLOCK_SCALES` to `FP8_PB_WO`. `hf_quant_config.json` still says `FP8_BLOCK_SCALES` for the same layer, and every weight shard is byte-identical (`group_size: 128`, per-128-block `weight_scale_inv`). `FP8_PB_WO` is ModelOpt's canonical name for per-block weight-only FP8; the image's `modelopt.py` already lists it, but only with a linear-layer method.

The recipe matches the old string exactly in two places, so a fresh clone against the current hub snapshot fails at Step 4g:

```
[ERR ]  MTP experts are FP8_PB_WO, which this image's mixed-precision MoE
        dispatch cannot build (supports FP8 / NVFP4 / W4A16_NVFP4 / MXFP8).
```

This PR treats `FP8_PB_WO` as an alias of `FP8_BLOCK_SCALES` in both places, so both names take the path this recipe already validated:

- `files/patch_checkpoint_config.py`: `SUPPORTED_MOE_ALGOS` gains `FP8_PB_WO` (with a comment recording the upstream rename).
- `files/patch_modelopt_fp8_block_moe.py`: the routed-expert branch becomes `if quant_algo in ("FP8_BLOCK_SCALES", "FP8_PB_WO"):` and routes to the same `Fp8MoEMethod` with `weight_block_size` read from `group_size`. The log line now prints the actual algo instead of a hardcoded `FP8_BLOCK_SCALES`.
- The idempotency guard keyed on `"FP8_BLOCK_SCALES" in src`. That would skip a `modelopt_patched.py` produced by the previous version of the script (which already contains the old `==` branch) and never add the alias. It now keys on the new branch text — the stock `modelopt.py` already contains `FP8_PB_WO` for linear layers, so that string alone is not a usable marker — and upgrades an old-form file in place.

Both halves are required: as #38 found, widening only the preflight lets the launch proceed and then fail ~7 min into loading with `Layer mtp.layers.48.mlp.experts has no parameter 'w2_weight_scale_inv'` because the runtime dispatch falls through to `None`.

No `.env` knob changes. No effect on measured numbers — the weights and block shape are unchanged; this restores the MTP3 configuration the README documents. Safe on both nodes: the patched `modelopt_patched.py` is the same file `start.sh` already scp's to the worker.

## Related Issues

Fixes #38.

Partially addresses #37 — this resolves its primary finding (the `FP8_PB_WO`
preflight abort and the matching runtime dispatch gap). It deliberately does
**not** close #37: that issue carries a second, still-unfixed finding
(`start.sh:239` resolving the snapshot with `ls -d snapshots/*/ | head -1`, which
can pick a partial revision directory), noted as out of scope at the bottom of
this description. #37 stays open to track it.

#37 contains the hub-revision diff establishing that only the label changed; #38 contains the runtime failure that shows the preflight-only workaround is insufficient.

---

## Testing

- `python3 -m py_compile` on both files.
- Preflight, against a copy of the current hub `config.json` (`FP8_PB_WO`): shipped script → `FP8_PB_WO  exit=3`; patched script → `FP8_PB_WO  exit=0`.
- Runtime patch, against the real `modelopt.py` from `vllm/vllm-openai:qwen38-flash-next`, three paths: fresh (after `patch_modelopt_mxfp8.py`) → `ok`, branch present at the dispatch site, file byte-compiles; second run → `already patched`; a `modelopt_patched.py` generated by the previous script version (old `==` branch) → `upgraded (FP8_PB_WO alias)`, one new-form branch, byte-compiles.
- Actual launch on 2× ASUS Ascent GX10 (GB10), TP2+EP over ConnectX-7 200 GbE, checkpoint `fc694b54`, MTP3, `KV_CACHE_DTYPE=fp8`, `GPU_MEMORY_UTILIZATION=0.835`:

```
Model loading took 64.3 GiB memory
Available KV cache memory: 35.31 GiB
GPU KV cache size: 3,784,544 tokens, Maximum concurrency for 262,144 tokens per request: 14.44x
```

`bench/mtp_accept.py`: 64.6% acceptance, 1.94 accepted/draft, positions 81.8% / 64.3% / 47.6%. Decode 47–53 tok/s single-stream vs 26–27 with `MTP_NUM_SPECULATIVE_TOKENS=0`.

Not in this PR (separate concern from #37): `start.sh` resolving the snapshot with `ls -d snapshots/*/ | head -1`, which can pick a partial revision directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcJBXab6sCmZji1r9ugsbK

