### PR TITLE
Accept FP8_PB_WO as MTP routed-expert quant algo (checkpoint rev fc694b54 rename)

### DIFF
--- a/files/patch_checkpoint_config.py
+++ b/files/patch_checkpoint_config.py
@@ -81,10 +81,11 @@ def add_aliases(quant_config: dict, num_hidden_layers: int) -> bool:
 # RoutedExperts algos ModelOptMixedPrecisionConfig.get_quant_method can build.
 # Anything else resolves to a *silently unquantized* MoE, which then dies at load
 # with "has no parameter 'w2_weight_scale_inv'".
+# FP8_PB_WO = NVIDIA renamed FP8_BLOCK_SCALES in rev fc694b54 (same 128x128 block FP8).
 # FP8_BLOCK_SCALES is supported only because files/patch_modelopt_fp8_block_moe.py
 # adds that branch; stock vLLM (image and upstream main) would build an
 # unquantized MoE and die at load.
-SUPPORTED_MOE_ALGOS = {"FP8", "NVFP4", "W4A16_NVFP4", "MXFP8", "FP8_BLOCK_SCALES"}
+SUPPORTED_MOE_ALGOS = {"FP8", "NVFP4", "W4A16_NVFP4", "MXFP8", "FP8_BLOCK_SCALES", "FP8_PB_WO"}
 
 
 def mtp_moe_algo(snapshot_dir: str) -> str:

--- a/files/patch_modelopt_fp8_block_moe.py
+++ b/files/patch_modelopt_fp8_block_moe.py
@@ -80,13 +80,13 @@ DISPATCH = """            if quant_algo == "MXFP8":
                     quant_config=self.mxfp8_config,
                     moe_config=layer.moe_config,
                 )
-            if quant_algo == "FP8_BLOCK_SCALES":
+            if quant_algo in ("FP8_BLOCK_SCALES", "FP8_PB_WO"):
                 # Imported lazily: modelopt.py deliberately does not import fp8.py
                 # at module scope.
                 from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
 
                 logger.info_once(
-                    "Routed experts %s use FP8_BLOCK_SCALES; building them with "
+                    "Routed experts %s use FP8_BLOCK_SCALES/FP8_PB_WO; building them with "
                     "Fp8MoEMethod (block-quantized).",
                     prefix,
                 )


### PR DESCRIPTION
## Description and Motivation

NVIDIA checkpoint revision `fc694b54` (2026-09-05, *"Fix MTP serving metadata and instructions"*) renamed the MTP routed-expert `quant_algo` in `config.json` (`quantization_config.quantized_layers`) from `FP8_BLOCK_SCALES` to `FP8_PB_WO`:

```
# fab0aecb (old):  mtp.layers.0.mlp.experts = {quant_algo: FP8_BLOCK_SCALES, group_size: 128}
# fc694b54 (now):  mtp.layers.0.mlp.experts = {quant_algo: FP8_PB_WO,       group_size: 128}
```

The weights are unchanged — the model card still describes 128×128 block-scaled FP8, and `FP8_PB_WO` already appears in `modelopt.py` as the per-block weight-only linear algo. But the rename breaks MTP speculative decoding for anyone downloading the current checkpoint:

1. `start.sh` step 4g preflight aborts: `patch_checkpoint_config.py --mtp-moe-algo` exits 3 because `FP8_PB_WO` is not in `SUPPORTED_MOE_ALGOS` → `start.sh` refuses to launch with `MTP_NUM_SPECULATIVE_TOKENS > 0`.
2. Even past the preflight, the `patch_modelopt_fp8_block_moe.py` dispatch branch only matches `FP8_BLOCK_SCALES`, so the MTP MoE would fall through to `None` and die at load with the familiar `has no parameter 'w2_weight_scale_inv'`.

This PR treats `FP8_PB_WO` identically to `FP8_BLOCK_SCALES` in both places (2-line functional change + comment). No `.env` knob or default changes; no effect on the measured KV cache / throughput numbers. Safe on both nodes: the change only widens a string match in the preflight whitelist and the bind-mounted dispatch patch.

## Related Issues

None filed — discovered while setting up against the current checkpoint revision.

---

## Testing

- Actual launch on a dual DGX Spark cluster (GB10, TP2+EP, `MTP_NUM_SPECULATIVE_TOKENS=3`, `KV_CACHE_DTYPE=auto`, YaRN @ 1M ctx) against `nvidia/Qwen3.8-Flash-Next-NVFP4` @ `fc694b54`:
  - Before: `start.sh` → `[ERR] MTP experts are FP8_PB_WO, which this image's mixed-precision MoE dispatch cannot build`
  - After: preflight passes (`MTP experts quantization: FP8_PB_WO (supported)`), and the runtime log shows the MTP MoE built correctly:
    ```
    Routed experts mtp.layers.48.mlp.experts use FP8_BLOCK_SCALES/FP8_PB_WO; building them with Fp8MoEMethod (block-quantized).
    ```
  - Server came up healthy: `Available KV cache memory: 35.21 GiB`, `GPU KV cache size: 2,431,888 tokens`, speculator captured its model, and `/v1/chat/completions` returns completions end-to-end.
- `python3 -c "import ast; ast.parse(...)"` on both modified files (no syntax errors).

---

## Checklist:

- [x] I have read the README and `.env.sample` and kept my changes consistent with them.
- [x] My pull request has a sound title and description (not something vague like `Update README.md`).
- [x] My change is reproducible and verified (e.g. script syntax check, a launch, or a re-measurement).
- [x] I updated the README and/or `.env.sample` if a `.env` knob, default, or measured number changed. *(N/A — no knob/default/number changes)*
- [x] Defaults in `.env.sample` still work out of the box; a new knob has a sane fallback like the existing ones. *(N/A — no new knob)*
