### PR TITLE
fix: resolve the launch snapshot via refs/main, not ls order

### DIFF
--- a/files/patch_checkpoint_config.py
+++ b/files/patch_checkpoint_config.py
@@ -20,8 +20,11 @@ and loading dies at:
   'mtp.layers.48.mlp.experts.0.down_proj.weight_scale_inv'
 
 BOTH files must be patched: `quantized_layers` appears in config.json's
-`quantization_config` *and* in the legacy hf_quant_config.json, and vLLM reads
-the legacy file when it is present. Patching only config.json is not enough.
+`quantization_config` *and* in the legacy hf_quant_config.json, and the two
+can disagree (nvidia/... rev fc694b54 says FP8_PB_WO in config.json and
+FP8_BLOCK_SCALES in the sidecar). Runtime evidence (issue #38) shows the MoE
+dispatch consumes config.json, so that file is the one that must be right.
+The sidecar is patched for consistency, not because it wins.
 
 Outputs go next to this script; start.sh bind-mounts them over the snapshot's
 copies in the container, so the HF cache is never modified.
@@ -126,7 +129,9 @@ def main(snapshot_dir: str, out_dir: str) -> None:
             json.dump(config, fh, indent=2)
         patched.append("config.json")
 
-    # Legacy sidecar — vLLM prefers it when present, so it needs the same fix.
+    # Legacy sidecar. Patched for consistency with config.json. Runtime
+    # evidence (issue #38) shows the MoE dispatch consumes config.json, so
+    # the config.json alias above is the load-bearing one.
     legacy_path = os.path.join(snapshot_dir, "hf_quant_config.json")
     if os.path.isfile(legacy_path):
         with open(legacy_path) as fh:

--- a/files/patch_modelopt_fp8_block_moe.py
+++ b/files/patch_modelopt_fp8_block_moe.py
@@ -107,6 +107,15 @@ def _replace_once(src: str, old: str, new: str, what: str) -> str:
 
 NEW_BRANCH = 'if quant_algo in ("FP8_BLOCK_SCALES", "FP8_PB_WO"):'
 OLD_BRANCH = 'if quant_algo == "FP8_BLOCK_SCALES":'
+# Same message change, for files patched by the earlier version of this script.
+# Without it an upgraded file keeps logging the old hardcoded name.
+OLD_LOG = '''"Routed experts %s use FP8_BLOCK_SCALES; building them with "
+                    "Fp8MoEMethod (block-quantized).",
+                    prefix,'''
+NEW_LOG = '''"Routed experts %s use %s; building them with "
+                    "Fp8MoEMethod (block-quantized).",
+                    prefix,
+                    quant_algo,'''
 
 
 def patch() -> None:
@@ -116,8 +125,10 @@ def patch() -> None:
         return
     if OLD_BRANCH in src:
         # Patched by an earlier version of this script: widen the branch to the
-        # FP8_PB_WO alias without re-applying the helper.
+        # FP8_PB_WO alias without re-applying the helper. Also carry the log
+        # line across, so the message prints the real algo, not the old name.
         src = _replace_once(src, OLD_BRANCH, NEW_BRANCH, "moe dispatch (alias upgrade)")
+        src = _replace_once(src, OLD_LOG, NEW_LOG, "moe dispatch log (alias upgrade)")
         open(TARGET, "w").write(src)
         print("upgraded (FP8_PB_WO alias)", TARGET)
         return

--- a/start.sh
+++ b/start.sh
@@ -234,9 +234,51 @@ fi
 # the FP8 PLE table only in quantization_config.config_groups). Recover it from
 # the checkpoint and feed it back via --hf-overrides below. Empty = already
 # declared, or no quantized PLE table.
+# PLE config must come from the snapshot the engine will load. refs/main
+# names that revision. Directory order does not. Never guess by ls order.
+# Fail fast on a broken download instead of patching the wrong tree.
+resolve_ple_config_dir() {  # sets PLE_CONFIG_DIR, exits loud on error
+    local ref_file="$HEAD_MODEL_PATH/refs/main"
+    local rev=""
+    if [[ -f "$ref_file" ]]; then
+        # huggingface_hub >= 1.x writes refs/main with a trailing newline,
+        # and stray spaces would poison the path the same way.
+        rev=$(tr -d '[:space:]' < "$ref_file")
+    fi
+    if [[ -n "$rev" ]]; then
+        PLE_CONFIG_DIR="$HEAD_MODEL_PATH/snapshots/$rev"
+        if [[ ! -d "$PLE_CONFIG_DIR" ]]; then
+            err "refs/main names revision '$rev' but snapshots/$rev is missing in $HEAD_MODEL_PATH. Re-run ./download.sh $MODEL_ID."
+        fi
+        if [[ ! -f "$PLE_CONFIG_DIR/config.json" ]]; then
+            err "refs/main names revision '$rev' but snapshots/$rev has no config.json (partial download). Delete $PLE_CONFIG_DIR and re-run ./download.sh $MODEL_ID."
+        fi
+        return 0
+    fi
+    # No refs/main at all. Accept the only snapshot. Refuse to guess
+    # between several. Called as a plain command, not in $(...), so the
+    # PLE_CONFIG_DIR assignment above survives (subshells drop it).
+    local found=()
+    local d
+    for d in "$HEAD_MODEL_PATH"/snapshots/*/; do
+        [[ -d "$d" ]] || continue
+        found+=("${d%/}")
+    done
+    if [[ ${#found[@]} -eq 1 ]]; then
+        PLE_CONFIG_DIR="${found[0]}"
+        if [[ ! -f "$PLE_CONFIG_DIR/config.json" ]]; then
+            err "Only snapshot ${found[0]} exists but it has no config.json (partial download). Delete it and re-run ./download.sh $MODEL_ID."
+        fi
+        return 0
+    fi
+    if [[ ${#found[@]} -eq 0 ]]; then
+        err "No snapshot under $HEAD_MODEL_PATH/snapshots. Re-run ./download.sh $MODEL_ID."
+    fi
+    err "Several snapshots under $HEAD_MODEL_PATH/snapshots but refs/main is missing. Delete stale revisions or re-run ./download.sh $MODEL_ID."
+}
 PLE_CONFIG_DIR="$MODEL_DIR"
 if [[ ! -f "$PLE_CONFIG_DIR/config.json" ]]; then
-    PLE_CONFIG_DIR=$(ls -d "$HEAD_MODEL_PATH"/snapshots/*/ 2>/dev/null | head -1)
+    resolve_ple_config_dir
 fi
 PLE_EMBEDDING_DTYPE="${PLE_EMBEDDING_DTYPE:-}"
 if [[ -z "$PLE_EMBEDDING_DTYPE" && -f "$PLE_CONFIG_DIR/config.json" ]]; then
@@ -466,8 +508,11 @@ if $DO_LAUNCH && [[ -n "${SNAPSHOT_SHA:-}" ]]; then
         ok "Checkpoint already declares absolute MTP layer indices"
     else
         # quantized_layers lives in BOTH config.json and the legacy
-        # hf_quant_config.json, and vLLM reads the legacy file when present —
-        # mounting only config.json leaves the stale mapping in play.
+        # hf_quant_config.json, and the two can disagree: nvidia/... rev
+        # fc694b54 says FP8_PB_WO in config.json and FP8_BLOCK_SCALES in the
+        # sidecar. Runtime evidence (issue #38) shows the MoE dispatch
+        # consumes config.json, so that mount is the one that must be right.
+        # The sidecar is mounted too, for consistency, not because it wins.
         for cfg_name in $PATCHED_FILES; do
             case "$cfg_name" in
                 config.json)         host_file="$SCRIPT_DIR/files/config_patched.json" ;;


### PR DESCRIPTION
Fixes #37.

## What

`start.sh` picked the PLE config snapshot with `ls -d snapshots/*/ | head -1`.
That order is lexicographic and unrelated to recency. Two failure modes:

1. Silent wrong answer. With two complete snapshots, `refs/main` can name one
   while `head -1` picks the other. Step 4g then patches and mounts configs
   into one snapshot while vLLM loads the other, and the MTP alias silently
   never applies.
2. Hard failure. An interrupted download leaves a partial revision dir with no
   `config.json`. If `head -1` picks it, step 4g dies with
   `patch_checkpoint_config: no config.json at ...`.

## Fix

`resolve_ple_config_dir()` in `start.sh` prefers the revision `refs/main`
names (trailing whitespace stripped) and requires it to contain `config.json`.
If that revision is missing or incomplete, it fails loud with an actionable
message instead of silently patching a different tree. Only when `refs/main`
is entirely absent is the sole snapshot accepted; several snapshots with no
`refs/main` is an error. The existing behavior where `MODEL_DIR` itself
already has a `config.json` (direct snapshot case) is preserved.

## Also in this commit

- `files/patch_modelopt_fp8_block_moe.py`: the FP8_PB_WO upgrade path now also
  carries the log line change, so an upgraded file prints the real algo
  instead of the old hardcoded name.
- `start.sh` and `files/patch_checkpoint_config.py`: corrected the
  "vLLM reads the legacy hf_quant_config.json" comments. Runtime evidence in
  #38 shows the MoE dispatch consumes `config.json`. Both files are still
  patched and mounted; the stated reason is now accurate.

## Testing

- 8 fixture cases for the resolver: refs to good snapshot, refs with trailing
  newline, refs to missing dir, refs to partial dir with a full one present,
  no refs with one snapshot, no refs with two, no refs with none, no refs
  with one partial. All behave as designed.
- Patcher: fresh, repeat, upgrade, and upgrade-then-repeat paths all pass,
  and the upgraded file byte-compiles.
- Preflight: `patch_checkpoint_config.py --mtp-moe-algo` against the real
  current nvidia `config.json` returns `FP8_PB_WO`, exit 0.
- `bash -n start.sh`, `py_compile` on both scripts.
